### PR TITLE
feat: Retarget from JSInteropHelpers to SerratedJSInterop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -284,6 +284,8 @@ node_modules/
 # Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
 *.vbw
 
+*.code-workspace
+
 # Visual Studio LightSwitch build output
 **/*.HTMLClient/GeneratedArtifacts
 **/*.DesktopClient/GeneratedArtifacts
@@ -352,4 +354,3 @@ MigrationBackup/
 /SerratedJQ/$tf1
 /SerratedJQLibrary/$tf1
 /SerratedJQSample/Sample.Mvc/wwwroot/package_*
-

--- a/SerratedJQLibrary/JSInteropHelpers/EmbeddedFiles/JQueryProxy.js
+++ b/SerratedJQLibrary/JSInteropHelpers/EmbeddedFiles/JQueryProxy.js
@@ -42,11 +42,16 @@ var Serrated = globalThis.Serrated || {};
     };
 
 
-
+    // Binds .on() events
+    // The approach uses a hybrid of passing serilized event object JSON and an array of HTMLElements/JQuery objects that the JSON references.
+    // Replacement placeholders are flagged in the JSON, and the C# side can unpack the array and re-associate the objects as needed.
+    // The goal is to allow native access to primitive values without needing interop for property accesses, nor mapping the entire event object structure.
     JQueryProxy.BindListener = function (jsObject, events, shouldConvertHtmlElement, action, selector)
     {
         let handler = function (e) {
             //console.log('On Fired');
+
+ 
             // declare a javascript array called replacers, and implement JSON.stringify with a replacer that adds items which are of type HTMLElements to the array
             var replacements = [];
             var eEncoded = JSON.stringify(e, function (key, value) {
@@ -63,7 +68,7 @@ var Serrated = globalThis.Serrated || {};
                 }
                 return value;
             });
-            // TODO: If we don't find any replacements then send null and supress the unpack GetArrayObjectItems call on C# side(unnecesary interop call).
+            // TODO: If we don't find any replacements then send null and supress the unpack GetArrayObjectItems call on C# side(unnecessary interop call).
             action(eEncoded, e.type, new ArrayObject(replacements));
        }.bind(jsObject);
 

--- a/SerratedJQLibrary/JSInteropHelpers/GlobalJS.cs
+++ b/SerratedJQLibrary/JSInteropHelpers/GlobalJS.cs
@@ -17,7 +17,8 @@ namespace SerratedSharp.JSInteropHelpers
             /// <param name="parameters">JSObjects or strings to log.</param>
             public static void Log(params object[] parameters)
             {
-                JSImportInstanceHelpers.CallJSOfSameName<object>(_console.Value, parameters);
+                throw new NotImplementedException();
+                //JSImportInstanceHelpers.CallJSOfSameName<object>(_console.Value, parameters);
             }
         }
     }

--- a/SerratedJQLibrary/JSInteropHelpers/JSImportInstanceHelpers.cs
+++ b/SerratedJQLibrary/JSInteropHelpers/JSImportInstanceHelpers.cs
@@ -1,164 +1,164 @@
-﻿namespace SerratedSharp.JSInteropHelpers;
+﻿//namespace SerratedSharp.JSInteropHelpers;
 
-using SerratedSharp.JSInteropHelpers;
-using SerratedSharp.JSInteropHelpers.Internal;
-using System;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices.JavaScript;
+//using SerratedSharp.JSInteropHelpers;
+//using SerratedSharp.JSInteropHelpers.Internal;
+//using System;
+//using System.Runtime.CompilerServices;
+//using System.Runtime.InteropServices.JavaScript;
 
-public static class JSImportInstanceHelpers
-{
-
-
-    // J should be a JSObject or other prmitiive JS type
-    public static J GetPropertyOfSameName<J>(JSObject jsObject, Breaker _ = default(Breaker), [CallerMemberName] string propertyName = null)
-    {
-        // convert C# PascalCase func name to JS lowerCamelCase
-        return GetProperty<J>(jsObject, propertyName); //CallJSFuncAsJSObject(jsObject, funcName, parameters);
-    }
-
-    // Added: Returns property as a wrapped instance of W
-    public static W GetPropertyOfSameNameAsWrapped<W>(JSObject jsObject, Breaker _ = default(Breaker), [CallerMemberName] string propertyName = null)
-        where W : IJSObjectWrapper<W>
-    {
-        JSObject jsProp = GetPropertyOfSameName<JSObject>(jsObject, _, propertyName);
-        return W.WrapInstance(jsProp);
-    }
-
-    // J should be a JSObject or other prmitiive JS type
-    public static J GetProperty<J>(JSObject jsObject, string propertyName)
-    {
-        object genericObject = JSInstanceProxy.PropertyByNameToObject(jsObject, ToJSCasing(propertyName));
-        // Console.WriteLine($"GetProperty: {propertyName}, {genericObject}, {genericObject?.GetType()?.Name}");
-        return (J)genericObject;
-    }
+//public static class JSImportInstanceHelpers
+//{
 
 
-    public static void SetProperty(JSObject jsObject, string propertyName, object value)
-        => JSInstanceProxy.SetPropertyByName(jsObject, ToJSCasing(propertyName), value);
+//    // J should be a JSObject or other prmitiive JS type
+//    public static J GetPropertyOfSameName<J>(JSObject jsObject, Breaker _ = default(Breaker), [CallerMemberName] string propertyName = null)
+//    {
+//        // convert C# PascalCase func name to JS lowerCamelCase
+//        return GetProperty<J>(jsObject, propertyName); //CallJSFuncAsJSObject(jsObject, funcName, parameters);
+//    }
+
+//    // Added: Returns property as a wrapped instance of W
+//    public static W GetPropertyOfSameNameAsWrapped<W>(JSObject jsObject, Breaker _ = default(Breaker), [CallerMemberName] string propertyName = null)
+//        where W : IJSObjectWrapper<W>
+//    {
+//        JSObject jsProp = GetPropertyOfSameName<JSObject>(jsObject, _, propertyName);
+//        return W.WrapInstance(jsProp);
+//    }
+
+//    // J should be a JSObject or other prmitiive JS type
+//    public static J GetProperty<J>(JSObject jsObject, string propertyName)
+//    {
+//        object genericObject = JSInstanceProxy.PropertyByNameToObject(jsObject, ToJSCasing(propertyName));
+//        // Console.WriteLine($"GetProperty: {propertyName}, {genericObject}, {genericObject?.GetType()?.Name}");
+//        return (J)genericObject;
+//    }
 
 
-    public static void SetPropertyOfSameName(JSObject jsObject, object value, Breaker _ = default(Breaker), [CallerMemberName] string propertyName = null)
-        => SetProperty(jsObject, propertyName, value);
+//    public static void SetProperty(JSObject jsObject, string propertyName, object value)
+//        => JSInstanceProxy.SetPropertyByName(jsObject, ToJSCasing(propertyName), value);
 
-    // TODO: Move static helpers to separete library
 
-    // This call automatically wraps a JSObject using type W's WrapInstance interface
-    public static W CallJSOfSameNameAsWrapped<W>(JSObject jsObject, object[] parameters, Breaker _ = default(Breaker), [CallerMemberName] string funcName = null)
-        where W : IJSObjectWrapper<W>
-    {        
-        JSObject jsObjectRtn = CallJSOfSameName<JSObject>(jsObject, parameters, _, funcName);
-        return W.WrapInstance(jsObjectRtn); // wrap JSObject with W's factory create method
-    }
+//    public static void SetPropertyOfSameName(JSObject jsObject, object value, Breaker _ = default(Breaker), [CallerMemberName] string propertyName = null)
+//        => SetProperty(jsObject, propertyName, value);
 
-    // J should be a JSObject or other prmitiive JS type
-    public static J CallJSOfSameName<J>(JSObject jsObject, object[] parameters, Breaker _ = default(Breaker), [CallerMemberName] string funcName = null)
-    {
-        // convert C# PascalCase func name to JS lowerCamelCase
-        return CallJSFunc<J>(jsObject, funcName, parameters); //CallJSFuncAsJSObject(jsObject, funcName, parameters);
-    }
+//    // TODO: Move static helpers to separete library
 
-    // J should be a JSObject or other prmitiive JS type
-    public static J CallJSFunc<J>(JSObject jsObject, string funcName, params object[] parameters)
-    {
-        object[] objs = UnwrapJSObjectParams(parameters);
-        object genericObject;
-        Type type = typeof(J);
-        if (type.IsArray)
-        {
-            //genericObject = JSInstanceProxy.FuncByNameAsArray(jsObject, ToJSCasing(funcName), objs);
-            //object[] objectArray = (object[])genericObject;
-            //object typedArray = objectArray.Select( a => Convert.ChangeType(a, type.GetElementType() ) ).ToArray< type.GetElementType() > ();
-            //return (J)typedArray;
+//    // This call automatically wraps a JSObject using type W's WrapInstance interface
+//    public static W CallJSOfSameNameAsWrapped<W>(JSObject jsObject, object[] parameters, Breaker _ = default(Breaker), [CallerMemberName] string funcName = null)
+//        where W : IJSObjectWrapper<W>
+//    {        
+//        JSObject jsObjectRtn = CallJSOfSameName<JSObject>(jsObject, parameters, _, funcName);
+//        return W.WrapInstance(jsObjectRtn); // wrap JSObject with W's factory create method
+//    }
 
-            switch(type.GetElementType())
-            {
-                case Type t when t == typeof(string): 
-                    genericObject = JSInstanceProxy.FuncByNameAsStringArray(jsObject, ToJSCasing(funcName), objs);
-                    return (J)genericObject;
-                case Type t when t == typeof(double): 
-                    genericObject = JSInstanceProxy.FuncByNameAsDoubleArray(jsObject, ToJSCasing(funcName), objs);
-                    return (J)genericObject;
-                // TODO: Implement other primitive types supported as marshalled arrays
-                default:
-                    throw new NotImplementedException($"CallJSFunc: Returning array of {type.GetElementType()} not implemented");
-            }
+//    // J should be a JSObject or other prmitiive JS type
+//    public static J CallJSOfSameName<J>(JSObject jsObject, object[] parameters, Breaker _ = default(Breaker), [CallerMemberName] string funcName = null)
+//    {
+//        // convert C# PascalCase func name to JS lowerCamelCase
+//        return CallJSFunc<J>(jsObject, funcName, parameters); //CallJSFuncAsJSObject(jsObject, funcName, parameters);
+//    }
 
-        }
-        else
-            genericObject = JSInstanceProxy.FuncByNameAsObject(jsObject, ToJSCasing(funcName), objs);
+//    // J should be a JSObject or other prmitiive JS type
+//    public static J CallJSFunc<J>(JSObject jsObject, string funcName, params object[] parameters)
+//    {
+//        object[] objs = UnwrapJSObjectParams(parameters);
+//        object genericObject;
+//        Type type = typeof(J);
+//        if (type.IsArray)
+//        {
+//            //genericObject = JSInstanceProxy.FuncByNameAsArray(jsObject, ToJSCasing(funcName), objs);
+//            //object[] objectArray = (object[])genericObject;
+//            //object typedArray = objectArray.Select( a => Convert.ChangeType(a, type.GetElementType() ) ).ToArray< type.GetElementType() > ();
+//            //return (J)typedArray;
+
+//            switch(type.GetElementType())
+//            {
+//                case Type t when t == typeof(string): 
+//                    genericObject = JSInstanceProxy.FuncByNameAsStringArray(jsObject, ToJSCasing(funcName), objs);
+//                    return (J)genericObject;
+//                case Type t when t == typeof(double): 
+//                    genericObject = JSInstanceProxy.FuncByNameAsDoubleArray(jsObject, ToJSCasing(funcName), objs);
+//                    return (J)genericObject;
+//                // TODO: Implement other primitive types supported as marshalled arrays
+//                default:
+//                    throw new NotImplementedException($"CallJSFunc: Returning array of {type.GetElementType()} not implemented");
+//            }
+
+//        }
+//        else
+//            genericObject = JSInstanceProxy.FuncByNameAsObject(jsObject, ToJSCasing(funcName), objs);
                 
-        return (J)genericObject;
-    }
+//        return (J)genericObject;
+//    }
 
-    public static object[] UnwrapJSObjectParams(object[] parameters)
-    {
-        object[] objs = null;
-        for (int i = 0; i < parameters.Length; i++)
-        {
-            object param = parameters[i];
-            //if(funcName == "Append")
-            //    Console.WriteLine($"CallJSFunc: {param}");
-            // if the param is a JSObject wrapper, then unwrap Wrappers to it's JSObject handle
-            if (param is IJSObjectWrapper wrapper)
-            {
-                if (objs == null) // if first time we converting a type, 
-                    objs = TypedArrayToObjectArray(parameters, i);// then need to create an untyped object array to allow reassignment of this element
+//    public static object[] UnwrapJSObjectParams(object[] parameters)
+//    {
+//        object[] objs = null;
+//        for (int i = 0; i < parameters.Length; i++)
+//        {
+//            object param = parameters[i];
+//            //if(funcName == "Append")
+//            //    Console.WriteLine($"CallJSFunc: {param}");
+//            // if the param is a JSObject wrapper, then unwrap Wrappers to it's JSObject handle
+//            if (param is IJSObjectWrapper wrapper)
+//            {
+//                if (objs == null) // if first time we converting a type, 
+//                    objs = TypedArrayToObjectArray(parameters, i);// then need to create an untyped object array to allow reassignment of this element
 
-                objs[i] = wrapper.JSObject;
-            }
+//                objs[i] = wrapper.JSObject;
+//            }
 
-            //parameters[i] = (param as IJSObjectWrapper)?.JSObject ?? param;
+//            //parameters[i] = (param as IJSObjectWrapper)?.JSObject ?? param;
 
-            //if (funcName == "Append")
-            //    Console.WriteLine($"CallJSFunc 2: {param}");
-        }
-        if (objs == null) // if no wrappers were found, then use original parameters array
-            objs = parameters;
-        return objs;
-    }
+//            //if (funcName == "Append")
+//            //    Console.WriteLine($"CallJSFunc 2: {param}");
+//        }
+//        if (objs == null) // if no wrappers were found, then use original parameters array
+//            objs = parameters;
+//        return objs;
+//    }
 
-    private static object[] TypedArrayToObjectArray(object[] objs, int index)
-    {
-        if(objs.GetType().GetElementType() == typeof(object))
-        {
-            return objs;
-        }
-        else
-        {
-            object[] objs2 = new object[objs.Length];
-            Array.Copy(objs, objs2, index+1);
-            //for(int i = 0; i < objs.Length; i++)
-            //{
-            //    objs2[i] = objs[i] as IJSObjectWrapper)?.JSObject ?? objs[i];
-            //}
-            return objs2;
-        }
-
-
-
-    }
-
-    // lower cases first character
-    public static string ToJSCasing(string identifier)
-        => Char.ToLowerInvariant(identifier[0]) + identifier.Substring(1);
+//    private static object[] TypedArrayToObjectArray(object[] objs, int index)
+//    {
+//        if(objs.GetType().GetElementType() == typeof(object))
+//        {
+//            return objs;
+//        }
+//        else
+//        {
+//            object[] objs2 = new object[objs.Length];
+//            Array.Copy(objs, objs2, index+1);
+//            //for(int i = 0; i < objs.Length; i++)
+//            //{
+//            //    objs2[i] = objs[i] as IJSObjectWrapper)?.JSObject ?? objs[i];
+//            //}
+//            return objs2;
+//        }
 
 
-    //public JQueryObject CallJSOfSameNameAsJQueryObject(object[] parameters, Breaker _ = default(Breaker), [CallerMemberName] string funcName = null)
-    //{
-    //    return CallJSOfSameNameAsWrapped<JQueryObject>(this.JSObject, parameters, _, funcName);
-    //}
 
-    //public string CallJSOfSameNameAsString(object[] parameters, Breaker _ = default(Breaker), [CallerMemberName] string funcName = null)
-    //{
-    //    return CallJSOfSameName<string>(this.JSObject, parameters, _, funcName);
-    //}
+//    }
 
-    //public R CallJSOfSameName<R>(object[] parameters, Breaker _ = default(Breaker), [CallerMemberName] string funcName = null)
-    //{
-    //    return CallJSOfSameName<R>(this.JSObject, parameters, _, funcName);
-    //}
+//    // lower cases first character
+//    public static string ToJSCasing(string identifier)
+//        => Char.ToLowerInvariant(identifier[0]) + identifier.Substring(1);
 
 
-}
+//    //public JQueryObject CallJSOfSameNameAsJQueryObject(object[] parameters, Breaker _ = default(Breaker), [CallerMemberName] string funcName = null)
+//    //{
+//    //    return CallJSOfSameNameAsWrapped<JQueryObject>(this.JSObject, parameters, _, funcName);
+//    //}
+
+//    //public string CallJSOfSameNameAsString(object[] parameters, Breaker _ = default(Breaker), [CallerMemberName] string funcName = null)
+//    //{
+//    //    return CallJSOfSameName<string>(this.JSObject, parameters, _, funcName);
+//    //}
+
+//    //public R CallJSOfSameName<R>(object[] parameters, Breaker _ = default(Breaker), [CallerMemberName] string funcName = null)
+//    //{
+//    //    return CallJSOfSameName<R>(this.JSObject, parameters, _, funcName);
+//    //}
+
+
+//}
 

--- a/SerratedJQLibrary/JSInteropHelpers/JSInteropHelpers.csproj
+++ b/SerratedJQLibrary/JSInteropHelpers/JSInteropHelpers.csproj
@@ -12,9 +12,9 @@
 
 	<!-- Nuget Package Definition -->
 	<PropertyGroup>
-		<AssemblyVersion>0.2.2.0</AssemblyVersion>
-		    <FileVersion>0.2.2.0</FileVersion>
-		        <Version>0.2.2</Version>
+		<AssemblyVersion>0.2.5.0</AssemblyVersion>
+		    <FileVersion>0.2.5.0</FileVersion>
+		        <Version>0.2.5</Version>
 		<Authors>SerratedSharpSolutions</Authors>
 		<Company>SerratedSharpSolutions</Company>
 		<RootNamespace>SerratedSharp.$(MSBuildProjectName)</RootNamespace>

--- a/SerratedJQLibrary/JSInteropHelpers/JSObjectExtensions.cs
+++ b/SerratedJQLibrary/JSInteropHelpers/JSObjectExtensions.cs
@@ -1,58 +1,83 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.JavaScript;
 using SerratedSharp.JSInteropHelpers.Internal;
 
 namespace SerratedSharp.JSInteropHelpers;
 
-public static class JSObjectExtensions
-{
+//public static class JSObjectExtensions
+//{
 
-    public static J GetPropertyOfSameName<J>(this IJSObjectWrapper wrapper, Breaker _ = default, [CallerMemberName] string propertyName = null)
-        => JSImportInstanceHelpers.GetPropertyOfSameName<J>(wrapper.JSObject, _, propertyName);
+//    public static J GetPropertyOfSameName<J>(this IJSObjectWrapper wrapper, Breaker _ = default, [CallerMemberName] string propertyName = null)
+//        => JSImportInstanceHelpers.GetPropertyOfSameName<J>(wrapper.JSObject, _, propertyName);
 
-    public static void SetPropertyOfSameName(this IJSObjectWrapper wrapper, object value, Breaker _ = default, [CallerMemberName] string propertyName = null)
-        => JSImportInstanceHelpers.SetPropertyOfSameName(wrapper.JSObject, value, _, propertyName);
+//    // New: wrapped variant returning W
+//    public static W GetPropertyOfSameNameAsWrapped<W>(this IJSObjectWrapper wrapper, Breaker _ = default, [CallerMemberName] string propertyName = null)
+//        where W : IJSObjectWrapper<W>
+//        => JSImportInstanceHelpers.GetPropertyOfSameNameAsWrapped<W>(wrapper.JSObject, _, propertyName);
 
-    // From old to fix array issue 
-    public static W CallJSOfSameNameAsWrapped<W>(this W wrapper, object[] parameters, Breaker _ = default(Breaker), [CallerMemberName] string funcName = null)
-    where W : IJSObjectWrapper<W>
-    => JSImportInstanceHelpers.CallJSOfSameNameAsWrapped<W>(wrapper.JSObject, parameters, _, funcName);
+//    public static void SetPropertyOfSameName(this IJSObjectWrapper wrapper, object value, Breaker _ = default, [CallerMemberName] string propertyName = null)
+//        => JSImportInstanceHelpers.SetPropertyOfSameName(wrapper.JSObject, value, _, propertyName);
 
-    public static W CallJSOfSameNameAsWrapped<W>(this W wrapper, Breaker _ = default, [CallerMemberName] string funcName = null)
-        where W : IJSObjectWrapper<W>
-        => CallJSOfSameNameAsWrappedInternal(wrapper, funcName, _);
+//    // From old to fix array issue 
+//    public static W CallJSOfSameNameAsWrapped<W>(this IJSObjectWrapper wrapper, object[] parameters, Breaker _ = default(Breaker), [CallerMemberName] string funcName = null)
+//    where W : IJSObjectWrapper<W>
+//    => JSImportInstanceHelpers.CallJSOfSameNameAsWrapped<W>(wrapper.JSObject, parameters, _, funcName);
+    
+//    public static W CallJSOfSameNameAsWrapped<W>(this W wrapper, object[] parameters, Breaker _ = default(Breaker), [CallerMemberName] string funcName = null)
+//where W : IJSObjectWrapper<W>
+//=> JSImportInstanceHelpers.CallJSOfSameNameAsWrapped<W>(wrapper.JSObject, parameters, _, funcName);
 
-    // this one getting called with single array object with a nested string array class names
-    public static W CallJSOfSameNameAsWrapped<W>(this W wrapper, object param1, Breaker _ = default, [CallerMemberName] string funcName = null)
-        where W : IJSObjectWrapper<W>
-        => CallJSOfSameNameAsWrappedInternal(wrapper, funcName, _, param1);
+//    // Overloads with IJSObjectWrapper as first param allow a different type to be returned per <W>
+//    public static W CallJSOfSameNameAsWrapped<W>(this IJSObjectWrapper wrapper, Breaker _ = default, [CallerMemberName] string funcName = null)
+//        where W : IJSObjectWrapper<W>
+//        => CallJSOfSameNameAsWrappedInternal<W>(wrapper, funcName, _);
+//    // Overloads with `this W wrapper` as first param, default to returning same type as calling type.  This overload isn't necessary if we wanted to make callers always specify <W>
+//    public static W CallJSOfSameNameAsWrapped<W>(this W wrapper, Breaker _ = default, [CallerMemberName] string funcName = null)
+//        where W : IJSObjectWrapper<W>
+//        => CallJSOfSameNameAsWrappedInternal<W>(wrapper, funcName, _);
 
-    public static W CallJSOfSameNameAsWrapped<W>(this W wrapper, object param1, object param2, Breaker _ = default, [CallerMemberName] string funcName = null)
-        where W : IJSObjectWrapper<W>
-        => CallJSOfSameNameAsWrappedInternal(wrapper, funcName, _, param1, param2);
 
-    public static W CallJSOfSameNameAsWrapped<W>(this W wrapper, Breaker _, string funcName, params object[] parameters)
-        where W : IJSObjectWrapper<W>
-        => CallJSOfSameNameAsWrappedInternal(wrapper, funcName, _, parameters);
+//    public static W CallJSOfSameNameAsWrapped<W>(this IJSObjectWrapper wrapper, object param1, Breaker _ = default, [CallerMemberName] string funcName = null)
+//        where W : IJSObjectWrapper<W>
+//        => CallJSOfSameNameAsWrappedInternal<W>(wrapper, funcName, _, param1);
 
-    private static W CallJSOfSameNameAsWrappedInternal<W>(W wrapper, string funcName, Breaker _, params object[] parameters)
-        where W : IJSObjectWrapper<W>
-        => JSImportInstanceHelpers.CallJSOfSameNameAsWrapped<W>(wrapper.JSObject, parameters, _, funcName);
+//    public static W CallJSOfSameNameAsWrapped<W>(this W wrapper, object param1, Breaker _ = default, [CallerMemberName] string funcName = null)
+//    where W : IJSObjectWrapper<W>
+//    => CallJSOfSameNameAsWrappedInternal<W>(wrapper, funcName, _, param1);
 
-    public static J CallJSOfSameName<J>(this IJSObjectWrapper wrapper, Breaker _ = default, [CallerMemberName] string funcName = null)
-        => CallJSOfSameNameInternal<J>(wrapper, funcName, _);
 
-    public static J CallJSOfSameName<J>(this IJSObjectWrapper wrapper, object param1, Breaker _ = default, [CallerMemberName] string funcName = null)
-        => CallJSOfSameNameInternal<J>(wrapper, funcName, _, param1);
+//    public static W CallJSOfSameNameAsWrapped<W>(this IJSObjectWrapper wrapper, object param1, object param2, Breaker _ = default, [CallerMemberName] string funcName = null)
+//        where W : IJSObjectWrapper<W>
+//        => CallJSOfSameNameAsWrappedInternal<W>(wrapper, funcName, _, param1, param2);
 
-    public static J CallJSOfSameName<J>(this IJSObjectWrapper wrapper, object param1, object param2, Breaker _ = default, [CallerMemberName] string funcName = null)
-        => CallJSOfSameNameInternal<J>(wrapper, funcName, _, param1, param2);
+//    public static W CallJSOfSameNameAsWrapped<W>(this W wrapper, object param1, object param2, Breaker _ = default, [CallerMemberName] string funcName = null)
+//        where W : IJSObjectWrapper<W>
+//        => CallJSOfSameNameAsWrappedInternal<W>(wrapper, funcName, _, param1, param2);
 
-    public static J CallJSOfSameName<J>(this IJSObjectWrapper wrapper, Breaker _, string funcName, params object[] parameters)
-        => CallJSOfSameNameInternal<J>(wrapper, funcName, _, parameters);
 
-    private static J CallJSOfSameNameInternal<J>(IJSObjectWrapper wrapper, string funcName, Breaker _, params object[] parameters)
-        => JSImportInstanceHelpers.CallJSOfSameName<J>(wrapper.JSObject, parameters, _, funcName);
-}
+
+//    public static W CallJSOfSameNameAsWrapped<W>(this IJSObjectWrapper wrapper, Breaker _, string funcName, params object[] parameters)
+//        where W : IJSObjectWrapper<W>
+//        => CallJSOfSameNameAsWrappedInternal<W>(wrapper, funcName, _, parameters);
+
+//    private static W CallJSOfSameNameAsWrappedInternal<W>(IJSObjectWrapper wrapper, string funcName, Breaker _, params object[] parameters)
+//        where W : IJSObjectWrapper<W>
+//        => JSImportInstanceHelpers.CallJSOfSameNameAsWrapped<W>(wrapper.JSObject, parameters, _, funcName);
+
+//    public static J CallJSOfSameName<J>(this IJSObjectWrapper wrapper, Breaker _ = default, [CallerMemberName] string funcName = null)
+//        => CallJSOfSameNameInternal<J>(wrapper, funcName, _);
+
+//    public static J CallJSOfSameName<J>(this IJSObjectWrapper wrapper, object param1, Breaker _ = default, [CallerMemberName] string funcName = null)
+//        => CallJSOfSameNameInternal<J>(wrapper, funcName, _, param1);
+
+//    public static J CallJSOfSameName<J>(this IJSObjectWrapper wrapper, object param1, object param2, Breaker _ = default, [CallerMemberName] string funcName = null)
+//        => CallJSOfSameNameInternal<J>(wrapper, funcName, _, param1, param2);
+
+//    public static J CallJSOfSameName<J>(this IJSObjectWrapper wrapper, Breaker _, string funcName, params object[] parameters)
+//        => CallJSOfSameNameInternal<J>(wrapper, funcName, _, parameters);
+
+//    private static J CallJSOfSameNameInternal<J>(IJSObjectWrapper wrapper, string funcName, Breaker _, params object[] parameters)
+//        => JSImportInstanceHelpers.CallJSOfSameName<J>(wrapper.JSObject, parameters, _, funcName);
+//}
 
 

--- a/SerratedJQLibrary/JSInteropHelpers/readme.md
+++ b/SerratedJQLibrary/JSInteropHelpers/readme.md
@@ -1,4 +1,9 @@
 
+
+> [!IMPORTANT] 
+> The JSInteropHelpers library was originally created for personal use in private projects and shared for reference.  It has been refined for broader usage and published under a new name: SerratedJSInterop.  This includes simplified naming, simplified usage, and generally more refined for general use.  The new NuGet package can be found under SerratedSharp.SerratedJSInterop and now has a dedicated repository at https://github.com/SerratedSharp/SerratedJSInterop 
+
+
 # SerratedSharp.JSInteropHelpers
 
 A class library to simplify creating .NET WASM wrappers on JS instances.  This library is leveraged by SerratedJQ, but is designed to be agnostic.  Otherwise it has not been thoroughly refined, but may be of use to others.
@@ -32,7 +37,7 @@ public class JQueryPlainObject : IJSObjectWrapper<JQueryPlainObject>
 
 `CallJSOFSameName*` methods leverage `[CallerMemberName]` to determine name of containing C# function, convert it to lower camel case, then call a method of that name on `this`'s containing `JSObject`.  The instance wrapper should implement IJSObjectWrapper<W> where W is the wrapping type, and holds a reference to the `JSObject` instance that it wraps. A C# call such as `instance.Filter(index)` would be translated to the javascript `jsObject["filter"].apply(jsObject, index);` which is a generic approach equivilant to `jsObject.filter(index);`.
 
-Note in the above examples, use of `Params.Merge` and `Params.PrependToArray` which is necesary in some cases where the C# params and Javascript params differ in regards to repeating params.
+Note in the above examples, use of `Params.Merge` and `Params.PrependToArray` which is necessary in some cases where the C# params and Javascript params differ in regards to repeating params.
 
 A wrapper would contain a reference to a JSObject, which is the .NET handle for the javascript object it wraps:
 

--- a/SerratedJQLibrary/Project2/Program.cs
+++ b/SerratedJQLibrary/Project2/Program.cs
@@ -1,4 +1,3 @@
-using SerratedSharp.JSInteropHelpers;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using System.Diagnostics;
@@ -20,7 +19,10 @@ internal class Program
         Console.WriteLine("JQuery Document Ready!");
 
         // Do something with JQuery
-        JQueryPlain.Select("#out").Append("<b>Appended</b>");
+        var outElem = JQueryPlain.Select("#out");
+        Console.WriteLine("Appending...");
+        outElem.Append("<b>Appended</b>");
+        Console.WriteLine("TestOrchestrator.Begin()");
 
         await TestOrchestrator.Begin();
 

--- a/SerratedJQLibrary/Project2/Project2.csproj
+++ b/SerratedJQLibrary/Project2/Project2.csproj
@@ -4,7 +4,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\JSInteropHelpers\JSInteropHelpers.csproj" />
     <ProjectReference Include="..\SerratedJQ\SerratedJQ.csproj" />
     <ProjectReference Include="..\Tests.Shared\Tests.Shared.csproj" />
   </ItemGroup>

--- a/SerratedJQLibrary/SerratedJQ.sln
+++ b/SerratedJQLibrary/SerratedJQ.sln
@@ -1,11 +1,8 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33205.214
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SerratedJQ", "SerratedJQ\SerratedJQ.csproj", "{56FD46D6-6986-4717-AC0F-A73A7CEC20DE}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests.UnoWasm", "Tests.Wasm\Tests.UnoWasm.csproj", "{A9B5C877-4C44-4C59-A953-783ED3023801}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BC0BDDF1-35D9-4DC2-9A1F-CFB148CADAE8}"
 	ProjectSection(SolutionItems) = preProject
@@ -20,10 +17,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests.Shared", "Tests.Share
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project2", "Project2\Project2.csproj", "{AD3E89CF-962F-423E-A497-90A41A563879}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpawnDev.BlazorJS", "..\SpawnDev.BlazorJS\SpawnDev.BlazorJS.csproj", "{A0AAE788-4109-50A2-18D2-53F3636908ED}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpawnDev.BlazorJS.PixiJS", "..\SpawnDev.BlazorJS.PixiJS\SpawnDev.BlazorJS.PixiJS.csproj", "{57FAB462-9D03-5EA3-7CD6-E118F221396B}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -34,10 +27,6 @@ Global
 		{56FD46D6-6986-4717-AC0F-A73A7CEC20DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{56FD46D6-6986-4717-AC0F-A73A7CEC20DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{56FD46D6-6986-4717-AC0F-A73A7CEC20DE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A9B5C877-4C44-4C59-A953-783ED3023801}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A9B5C877-4C44-4C59-A953-783ED3023801}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A9B5C877-4C44-4C59-A953-783ED3023801}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A9B5C877-4C44-4C59-A953-783ED3023801}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2D8692DA-95E6-4F9E-B9C4-FBB14FBAACC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2D8692DA-95E6-4F9E-B9C4-FBB14FBAACC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D8692DA-95E6-4F9E-B9C4-FBB14FBAACC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -54,14 +43,6 @@ Global
 		{AD3E89CF-962F-423E-A497-90A41A563879}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AD3E89CF-962F-423E-A497-90A41A563879}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AD3E89CF-962F-423E-A497-90A41A563879}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A0AAE788-4109-50A2-18D2-53F3636908ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A0AAE788-4109-50A2-18D2-53F3636908ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A0AAE788-4109-50A2-18D2-53F3636908ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A0AAE788-4109-50A2-18D2-53F3636908ED}.Release|Any CPU.Build.0 = Release|Any CPU
-		{57FAB462-9D03-5EA3-7CD6-E118F221396B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{57FAB462-9D03-5EA3-7CD6-E118F221396B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{57FAB462-9D03-5EA3-7CD6-E118F221396B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{57FAB462-9D03-5EA3-7CD6-E118F221396B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SerratedJQLibrary/SerratedJQ/Archive/EmbeddedJavascript/JQueryProxy.js
+++ b/SerratedJQLibrary/SerratedJQ/Archive/EmbeddedJavascript/JQueryProxy.js
@@ -63,7 +63,7 @@ var Serrated = globalThis.Serrated || {};
                 }
                 return value;
             });
-            // TODO: If we don't find any replacements then send null and supress the unpack GetArrayObjectItems call on C# side(unnecesary interop call).
+            // TODO: If we don't find any replacements then send null and supress the unpack GetArrayObjectItems call on C# side(unnecessary interop call).
             action(eEncoded, e.type, new ArrayObject(replacements));
        }.bind(jsObject);
 

--- a/SerratedJQLibrary/SerratedJQ/CopySerratedJQToWasmScripts.ps1
+++ b/SerratedJQLibrary/SerratedJQ/CopySerratedJQToWasmScripts.ps1
@@ -1,0 +1,17 @@
+# Copies SerratedJQ.js from this project's wwwroot and transforms for AMD/RequireJS (Uno WasmScripts).
+# Wraps content in define(() => { ... }); and strips ES module exports, matching SerratedJSInterop pattern.
+# Usage: .\CopySerratedJQToWasmScripts.ps1 -SourcePath <path> -DestPath <path>
+param(
+    [Parameter(Mandatory=$true)][string]$SourcePath,
+    [Parameter(Mandatory=$true)][string]$DestPath
+)
+$content = [System.IO.File]::ReadAllText($SourcePath)
+$content = "define(() => {`n`n" + $content
+# Strip ES module exports and close the define callback (AMD/RequireJS for Uno WasmScripts)
+$content = $content -replace 'export const LoadJQuery = SerratedJQ\.LoadJQuery;[\r\n]*', ''
+$content = $content -replace 'export \{ SerratedJQ \};', '});'
+$dir = [System.IO.Path]::GetDirectoryName($DestPath)
+if (-not [System.IO.Directory]::Exists($dir)) {
+    [System.IO.Directory]::CreateDirectory($dir) | Out-Null
+}
+[System.IO.File]::WriteAllText($DestPath, $content)

--- a/SerratedJQLibrary/SerratedJQ/HtmlElement.cs
+++ b/SerratedJQLibrary/SerratedJQ/HtmlElement.cs
@@ -1,12 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using static System.Console;
 using System.Linq;
 using System.Dynamic;
 using Newtonsoft.Json;
 using System.Runtime.InteropServices.JavaScript;
-using SerratedSharp.JSInteropHelpers;
-using Params = SerratedSharp.JSInteropHelpers.ParamsHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 
 namespace SerratedSharp.SerratedJQ;
@@ -21,7 +20,7 @@ public class HtmlElement : IJSObjectWrapper<HtmlElement>, IJQueryContentParamete
         // instances can only be created thru factory methods like Select()/ParseHtml()
         internal HtmlElement() { }
         public HtmlElement(JSObject jsObject) { this.jsObject = jsObject; }
-        // This static factory method defined by the IJSObjectWrapper enables generic code such as CallJSOfSameNameAsWrapped to automatically wrap JSObjectsWrap
+        // This static factory method defined by the IJSObjectWrapper enables generic code such as CallJS<HtmlElement> to automatically wrap JSObject results
         static HtmlElement IJSObjectWrapper<HtmlElement>.WrapInstance(JSObject jsObject)
         {
             return new HtmlElement(jsObject); 

--- a/SerratedJQLibrary/SerratedJQ/JQIndexer.cs
+++ b/SerratedJQLibrary/SerratedJQ/JQIndexer.cs
@@ -1,6 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
-using SerratedSharp.JSInteropHelpers.Internal;
-using System.Collections.Generic;
+using SerratedSharp.SerratedJSInterop;
 
 namespace SerratedSharp.SerratedJQ;
 
@@ -17,8 +15,8 @@ public class JQIndexer<TWrapper, TKey1, TValue1> where TWrapper : IJSObjectWrapp
 
     public TValue1 this[TKey1 key]
     {
-        get => jsWrapper.CallJSOfSameName<TValue1>(key, default(Breaker), funcName);
-        set => jsWrapper.CallJSOfSameName<object>(key, value, default(Breaker), funcName);
+        get => jsWrapper.CallJS<TValue1>(funcName: funcName, key);
+        set => jsWrapper.CallJS<object>(funcName: funcName, key, value);
     }
 }
 
@@ -36,14 +34,14 @@ public class JQIndexer<TWrapper, TKey1, TValue1, TKey2, TValue2> where TWrapper 
 
     public TValue1 this[TKey1 key]
     {
-        get => jsWrapper.CallJSOfSameName<TValue1>(key, default(Breaker), funcName);
-        set => jsWrapper.CallJSOfSameName<object>(key, value, default(Breaker), funcName);
+        get => jsWrapper.CallJS<TValue1>(funcName: funcName, key);
+        set => jsWrapper.CallJS<object>(funcName: funcName, key, value);
     }
 
     public TValue2 this[TKey2 key]
     {
-        get => jsWrapper.CallJSOfSameName<TValue2>(key, default(Breaker), funcName);
-        set => jsWrapper.CallJSOfSameName<object>(key, value, default(Breaker), funcName);
+        get => jsWrapper.CallJS<TValue2>(funcName: funcName, key);
+        set => jsWrapper.CallJS<object>(funcName: funcName, key, value);
     }
 }
 
@@ -60,6 +58,6 @@ public class ReadOnlyJQIndexer<TWrapper, TKey1, TValue1> where TWrapper : IJSObj
 
     public TValue1 this[TKey1 key]
     {
-        get => jsWrapper.CallJSOfSameName<TValue1>(key, default(Breaker), funcName);
+        get => jsWrapper.CallJS<TValue1>(funcName: funcName, key);
     }
 }

--- a/SerratedJQLibrary/SerratedJQ/JQueryProxy.cs
+++ b/SerratedJQLibrary/SerratedJQ/JQueryProxy.cs
@@ -1,8 +1,9 @@
-﻿using System.Runtime.InteropServices.JavaScript;
 using System;
 using System.Threading.Tasks;
+using System.Runtime.InteropServices.JavaScript;
+using SerratedSharp.SerratedJSInterop;
 
-namespace SerratedSharp.JSInteropHelpers;
+namespace SerratedSharp.SerratedJQ;
 
 // Proxy for javascript declaration in JQueryProxy.js
 //internal static partial class JQueryProxy //: IJSObject
@@ -48,7 +49,7 @@ internal static class JQueryProxy //: IJSObject
 
     public static Task Ready()
     {
-        if (HelpersJS.IsUnoWasmBootstrapLoaded)
+        if (AgnosticRuntime.IsUnoWasmBootstrapLoaded)
             return JQueryProxyForUno.Ready();
         else
             return JQueryProxyForDotNet.Ready();
@@ -56,7 +57,7 @@ internal static class JQueryProxy //: IJSObject
 
     public static  JSObject Select(string selector)
     {
-        if (HelpersJS.IsUnoWasmBootstrapLoaded)
+        if (AgnosticRuntime.IsUnoWasmBootstrapLoaded)
             return JQueryProxyForUno.Select(selector);
         else
             return JQueryProxyForDotNet.Select(selector);
@@ -64,7 +65,7 @@ internal static class JQueryProxy //: IJSObject
 
     public static  JSObject ParseHtml(string html, bool keepScript)
         {
-        if (HelpersJS.IsUnoWasmBootstrapLoaded)
+        if (AgnosticRuntime.IsUnoWasmBootstrapLoaded)
             return JQueryProxyForUno.ParseHtml(html, keepScript);
         else
             return JQueryProxyForDotNet.ParseHtml(html, keepScript);
@@ -73,7 +74,7 @@ internal static class JQueryProxy //: IJSObject
     public static JSObject BindListener(JSObject jqObject, string events, bool shouldConvertHtmlElement,
      Action<string, string, JSObject> handler, string selector)
     {
-        if (HelpersJS.IsUnoWasmBootstrapLoaded)
+        if (AgnosticRuntime.IsUnoWasmBootstrapLoaded)
             return JQueryProxyForUno.BindListener(jqObject, events, shouldConvertHtmlElement, handler, selector);
         else
             return JQueryProxyForDotNet.BindListener(jqObject, events, shouldConvertHtmlElement, handler, selector);
@@ -81,14 +82,13 @@ internal static class JQueryProxy //: IJSObject
 
     public static void UnbindListener(JSObject jqObject, string events, JSObject handler, string selector)
     {
-        if (HelpersJS.IsUnoWasmBootstrapLoaded)
+        if (AgnosticRuntime.IsUnoWasmBootstrapLoaded)
             JQueryProxyForUno.UnbindListener(jqObject, events, handler, selector);
         else
             JQueryProxyForDotNet.UnbindListener(jqObject, events, handler, selector);
     }
 
 }
-
 
 // JQueryProxyForDotNet
 internal static partial class JQueryProxyForDotNet //: IJSObject

--- a/SerratedJQLibrary/SerratedJQ/Plain/IJQueryContentParameter.cs
+++ b/SerratedJQLibrary/SerratedJQ/Plain/IJQueryContentParameter.cs
@@ -1,13 +1,12 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 
 namespace SerratedSharp.SerratedJQ.Plain;
-
 
 // TODO: A way to flag all types that are valid for JQuery "Content" parameter?
 // Note we probably shouldn't inherit from IJSObjectWrapper, and instead let methods test
 // content types for the interface on the fly
 // Note: Using this as a return param should probably be discouraged because it lacks specificity.  It should typically only be an input param.
-public interface IJQueryContentParameter:IJSObjectWrapper
+public interface IJQueryContentParameter : IJSObjectWrapper
 {
 
 }

--- a/SerratedJQLibrary/SerratedJQ/Plain/JQueryPlain.cs
+++ b/SerratedJQLibrary/SerratedJQ/Plain/JQueryPlain.cs
@@ -1,8 +1,7 @@
-﻿//using Uno.Extensions;
+//using Uno.Extensions;
 //using Uno.Foundation.Interop;
 //using Uno.Foundation.Interop;
 
-using SerratedSharp.JSInteropHelpers;
 using System;
 using System.Threading.Tasks;
 

--- a/SerratedJQLibrary/SerratedJQ/Plain/JQueryPlainObject.cs
+++ b/SerratedJQLibrary/SerratedJQ/Plain/JQueryPlainObject.cs
@@ -1,16 +1,22 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using static System.Console;
 using System.Linq;
 using System.Dynamic;
 using Newtonsoft.Json;
 using System.Runtime.InteropServices.JavaScript;
-using SerratedSharp.JSInteropHelpers;
-using Params = SerratedSharp.JSInteropHelpers.ParamsHelpers;
-using System.Net;
+using SerratedSharp.SerratedJSInterop;
 using System.Diagnostics.CodeAnalysis;
 
 namespace SerratedSharp.SerratedJQ.Plain;
+
+internal static class SerratedJQParams
+{
+    internal static object[] Merge(object first, object[] rest) =>
+        rest == null || rest.Length == 0 ? new[] { first } : new[] { first }.Concat(rest).ToArray();
+    internal static object[] Prepend(object first, object[] rest) =>
+        rest == null || rest.Length == 0 ? new[] { first } : new[] { first }.Concat(rest).ToArray();
+}
 
 // Wrapper that references a JQuery instance object, i.e. the collection returned from selectors/queries
 public class JQueryPlainObject : IJSObjectWrapper<JQueryPlainObject>, IJQueryContentParameter
@@ -25,7 +31,7 @@ public class JQueryPlainObject : IJSObjectWrapper<JQueryPlainObject>, IJQueryCon
     // instances can only be created thru factory methods like Select()/ParseHtml()
     internal JQueryPlainObject() { }
     public JQueryPlainObject(JSObject jsObject) { this.jsObject = jsObject; }
-    // This static factory method defined by the IJSObjectWrapper enables generic code such as CallJSOfSameNameAsWrapped to automatically wrap JSObjectsWrap
+    // This static factory method defined by the IJSObjectWrapper enables generic code such as CallJS<JQueryPlainObject> to automatically wrap JSObject results
     static JQueryPlainObject IJSObjectWrapper<JQueryPlainObject>.WrapInstance(JSObject jsObject)
     {
         return new JQueryPlainObject(jsObject);
@@ -41,16 +47,16 @@ public class JQueryPlainObject : IJSObjectWrapper<JQueryPlainObject>, IJQueryCon
 
     #region Traversal - Filtering - https://api.jquery.com/category/traversing/filtering/
 
-    public JQueryPlainObject First() => this.CallJSOfSameNameAsWrapped();
-    public JQueryPlainObject Last() => this.CallJSOfSameNameAsWrapped();
-    public JQueryPlainObject Eq(int index) => this.CallJSOfSameNameAsWrapped(index);
-    public JQueryPlainObject Slice(int start, int end) => this.CallJSOfSameNameAsWrapped(start, end);
-    public JQueryPlainObject Filter(string selector) => this.CallJSOfSameNameAsWrapped(selector);
-    public JQueryPlainObject Has(string selector) => this.CallJSOfSameNameAsWrapped(selector);
-    public JQueryPlainObject Not(string selector) => this.CallJSOfSameNameAsWrapped(selector);
-    public bool Is(string selector) => this.CallJSOfSameName<bool>(selector);
-    public JQueryPlainObject Odd() => this.CallJSOfSameNameAsWrapped();
-    public JQueryPlainObject Even() => this.CallJSOfSameNameAsWrapped();
+    public JQueryPlainObject First() => this.CallJS<JQueryPlainObject>();
+    public JQueryPlainObject Last() => this.CallJS<JQueryPlainObject>();
+    public JQueryPlainObject Eq(int index) => this.CallJS<JQueryPlainObject>(index);
+    public JQueryPlainObject Slice(int start, int end) => this.CallJS<JQueryPlainObject>(start, end);
+    public JQueryPlainObject Filter(string selector) => this.CallJS<JQueryPlainObject>(selector);
+    public JQueryPlainObject Has(string selector) => this.CallJS<JQueryPlainObject>(selector);
+    public JQueryPlainObject Not(string selector) => this.CallJS<JQueryPlainObject>(selector);
+    public bool Is(string selector) => this.CallJS<bool>(selector);
+    public JQueryPlainObject Odd() => this.CallJS<JQueryPlainObject>();
+    public JQueryPlainObject Even() => this.CallJS<JQueryPlainObject>();
     //Map only takes a predicate: https://api.jquery.com/map/#map-callback
     //public JQueryObject Map(
 
@@ -58,107 +64,107 @@ public class JQueryPlainObject : IJSObjectWrapper<JQueryPlainObject>, IJQueryCon
     //      A collection of Elements: https://api.jquery.com/filter/#filter-elements
     //      A collection of JQuery object collection: https://api.jquery.com/filter/#filter-selection
     //      Unsure if we can implement a predicate parameter: https://api.jquery.com/filter/#filter-function
-    //public JQueryObject Filter(Func<int, bool> predicate) => this.CallJSOfSameNameAsWrapped(predicate);
-    //public JQueryObject Filter(Func<int, JQueryObject, bool> predicate) => this.CallJSOfSameNameAsWrapped(predicate);
+    //public JQueryObject Filter(Func<int, bool> predicate) => this.CallJS<JQueryPlainObject>(predicate);
+    //public JQueryObject Filter(Func<int, JQueryObject, bool> predicate) => this.CallJS<JQueryPlainObject>(predicate);
 
     #endregion
     #region Traversal - Tree Traversal - https://api.jquery.com/category/traversing/tree-traversal/
 
-    public JQueryPlainObject Children(string selector = null) => this.CallJSOfSameNameAsWrapped(selector);
-    public JQueryPlainObject Closest(string selector) => this.CallJSOfSameNameAsWrapped(selector);
-    public JQueryPlainObject Find(string selector) => this.CallJSOfSameNameAsWrapped(selector);
-    public JQueryPlainObject Next(string selector = null) => this.CallJSOfSameNameAsWrapped(selector);
-    public JQueryPlainObject NextAll(string selector = null) => this.CallJSOfSameNameAsWrapped(selector);
+    public JQueryPlainObject Children(string selector = null) => this.CallJS<JQueryPlainObject>(selector);
+    public JQueryPlainObject Closest(string selector) => this.CallJS<JQueryPlainObject>(selector);
+    public JQueryPlainObject Find(string selector) => this.CallJS<JQueryPlainObject>(selector);
+    public JQueryPlainObject Next(string selector = null) => this.CallJS<JQueryPlainObject>(selector);
+    public JQueryPlainObject NextAll(string selector = null) => this.CallJS<JQueryPlainObject>(selector);
     public JQueryPlainObject NextUntil(string stopAtSelector = null, string filterResultsSelector = null)
-        => this.CallJSOfSameNameAsWrapped(stopAtSelector, filterResultsSelector);
-    public JQueryPlainObject OffsetParent() => this.CallJSOfSameNameAsWrapped();
-    public JQueryPlainObject Parent(string selector = null) => this.CallJSOfSameNameAsWrapped(selector);
-    public JQueryPlainObject Parents(string selector = null) => this.CallJSOfSameNameAsWrapped(selector);
+        => this.CallJS<JQueryPlainObject>(stopAtSelector, filterResultsSelector);
+    public JQueryPlainObject OffsetParent() => this.CallJS<JQueryPlainObject>();
+    public JQueryPlainObject Parent(string selector = null) => this.CallJS<JQueryPlainObject>(selector);
+    public JQueryPlainObject Parents(string selector = null) => this.CallJS<JQueryPlainObject>(selector);
     public JQueryPlainObject ParentsUntil(string stopAtSelector = null, string filterResultsSelector = null)
-        => this.CallJSOfSameNameAsWrapped(stopAtSelector, filterResultsSelector);
-    public JQueryPlainObject Prev(string selector = null) => this.CallJSOfSameNameAsWrapped(selector);
-    public JQueryPlainObject PrevAll(string selector = null) => this.CallJSOfSameNameAsWrapped(selector);
+        => this.CallJS<JQueryPlainObject>(stopAtSelector, filterResultsSelector);
+    public JQueryPlainObject Prev(string selector = null) => this.CallJS<JQueryPlainObject>(selector);
+    public JQueryPlainObject PrevAll(string selector = null) => this.CallJS<JQueryPlainObject>(selector);
     public JQueryPlainObject PrevUntil(string stopAtSelector = null, string filterResultsSelector = null)
-        => this.CallJSOfSameNameAsWrapped(stopAtSelector, filterResultsSelector);
-    public JQueryPlainObject Siblings(string selector = null) => this.CallJSOfSameNameAsWrapped(selector);
+        => this.CallJS<JQueryPlainObject>(stopAtSelector, filterResultsSelector);
+    public JQueryPlainObject Siblings(string selector = null) => this.CallJS<JQueryPlainObject>(selector);
 
     #endregion
     #region Traversal - Miscellaneous - https://api.jquery.com/category/traversing/miscellaneous-traversal/
 
-    public JQueryPlainObject Add(string selector) => this.CallJSOfSameNameAsWrapped(selector);
-    public JQueryPlainObject Add(JQueryPlainObject jqObject) => this.CallJSOfSameNameAsWrapped(jqObject);
-    public JQueryPlainObject Add(string selector, JQueryPlainObject context) => this.CallJSOfSameNameAsWrapped(selector, context);
-    public JQueryPlainObject AddBack(string selector = null) => this.CallJSOfSameNameAsWrapped(selector);
-    public JQueryPlainObject Contents() => this.CallJSOfSameNameAsWrapped();
-    public JQueryPlainObject End() => this.CallJSOfSameNameAsWrapped();
+    public JQueryPlainObject Add(string selector) => this.CallJS<JQueryPlainObject>(selector);
+    public JQueryPlainObject Add(JQueryPlainObject jqObject) => this.CallJS<JQueryPlainObject>(jqObject);
+    public JQueryPlainObject Add(string selector, JQueryPlainObject context) => this.CallJS<JQueryPlainObject>(selector, context);
+    public JQueryPlainObject AddBack(string selector = null) => this.CallJS<JQueryPlainObject>(selector);
+    public JQueryPlainObject Contents() => this.CallJS<JQueryPlainObject>();
+    public JQueryPlainObject End() => this.CallJS<JQueryPlainObject>();
 
     #endregion
 
     #region General Attributes - https://api.jquery.com/category/attributes/general-attributes/
 
-    public string Attr(string attributeName) => this.CallJSOfSameName<string>(attributeName);
-    public void Attr(string attributeName, string value) => this.CallJSOfSameName<object>(attributeName, value);
-    //public void Attr(string attributeName, bool value) => this.CallJSOfSameName<object>(attributeName, value);        
-    public void Attr(string attributeName, int? value) => this.CallJSOfSameName<object>(attributeName, value);
-    public void Attr(string attributeName, double? value) => this.CallJSOfSameName<object>(attributeName, value);
-    //public void Attr(string attributeName, object value) => this.CallJSOfSameName<object>(attributeName, value);
-    public void RemoveAttr(string attributeName) => this.CallJSOfSameName<object>(attributeName);
+    public string Attr(string attributeName) => this.CallJS<string>(attributeName);
+    public void Attr(string attributeName, string value) => this.CallJS<object>(attributeName, value);
+    //public void Attr(string attributeName, bool value) => this.CallJS<object>(attributeName, value);        
+    public void Attr(string attributeName, int? value) => this.CallJS<object>(attributeName, value);
+    public void Attr(string attributeName, double? value) => this.CallJS<object>(attributeName, value);
+    //public void Attr(string attributeName, object value) => this.CallJS<object>(attributeName, value);
+    public void RemoveAttr(string attributeName) => this.CallJS<object>(attributeName);
     // TODO: Implementat validation and throw NotImplemented for return types <R> which are not supported by JQuery, perhaps using method attributes to declare valid types
-    public R Prop<R>(string propertyName) => this.CallJSOfSameName<R>(propertyName);
-    public void Prop(string propertyName, string value) => this.CallJSOfSameName<object>(propertyName, value);
-    //public void Prop(string propertyName, bool value) => this.CallJSOfSameName<object>(propertyName, value);        
-    //public void Prop(string propertyName, int? value) => this.CallJSOfSameName<object>(propertyName, value);
-    public void Prop(string propertyName, double? value) => this.CallJSOfSameName<object>(propertyName, value);
-    //public void Prop(string propertyName, object value) => this.CallJSOfSameName<object>(propertyName, value);
-    public void RemoveProp(string propertyName) => this.CallJSOfSameName<object>(propertyName);
+    public R Prop<R>(string propertyName) => this.CallJS<R>(propertyName);
+    public void Prop(string propertyName, string value) => this.CallJS<object>(propertyName, value);
+    //public void Prop(string propertyName, bool value) => this.CallJS<object>(propertyName, value);        
+    //public void Prop(string propertyName, int? value) => this.CallJS<object>(propertyName, value);
+    public void Prop(string propertyName, double? value) => this.CallJS<object>(propertyName, value);
+    //public void Prop(string propertyName, object value) => this.CallJS<object>(propertyName, value);
+    public void RemoveProp(string propertyName) => this.CallJS<object>(propertyName);
 
 
-    public string Val() => this.CallJSOfSameName<string>();
-    public T Val<T>() => this.CallJSOfSameName<T>();
+    public string Val() => this.CallJS<string>();
+    public T Val<T>() => this.CallJS<T>();
     
-    public JQueryPlainObject Val(string value) => this.CallJSOfSameNameAsWrapped(value);
-    public JQueryPlainObject Val(double value) => this.CallJSOfSameNameAsWrapped(value);
-    public JQueryPlainObject Val(string[] value) => this.CallJSOfSameNameAsWrapped(new object[] { value });
+    public JQueryPlainObject Val(string value) => this.CallJS<JQueryPlainObject>(value);
+    public JQueryPlainObject Val(double value) => this.CallJS<JQueryPlainObject>(value);
+    public JQueryPlainObject Val(string[] value) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(new object[] { value }));
 
     #endregion
 
     #region Style Properties - https://api.jquery.com/category/manipulation/style-properties/
     // Also include the couple of items from CSS that aren't in any other category: https://api.jquery.com/category/css/    
 
-    public string Css(string propertyName) => this.CallJSOfSameName<string>(propertyName);
-    public JQueryPlainObject Css(string propertyName, string value) => this.CallJSOfSameNameAsWrapped(propertyName, value);
+    public string Css(string propertyName) => this.CallJS<string>(propertyName);
+    public JQueryPlainObject Css(string propertyName, string value) => this.CallJS<JQueryPlainObject>(propertyName, value);
 
     // TODO: cssNumber https://api.jquery.com/jQuery.cssNumber/ 
 
-    public double Height() => this.CallJSOfSameName<double>();
-    public JQueryPlainObject Height(string value) => this.CallJSOfSameNameAsWrapped(value);
-    public JQueryPlainObject Height(double value) => this.CallJSOfSameNameAsWrapped(value);
+    public double Height() => this.CallJS<double>();
+    public JQueryPlainObject Height(string value) => this.CallJS<JQueryPlainObject>(value);
+    public JQueryPlainObject Height(double value) => this.CallJS<JQueryPlainObject>(value);
 
-    public double Width() => this.CallJSOfSameName<double>();
-    public JQueryPlainObject Width(string value) => this.CallJSOfSameNameAsWrapped(value);
-    public JQueryPlainObject Width(double value) => this.CallJSOfSameNameAsWrapped(value);
+    public double Width() => this.CallJS<double>();
+    public JQueryPlainObject Width(string value) => this.CallJS<JQueryPlainObject>(value);
+    public JQueryPlainObject Width(double value) => this.CallJS<JQueryPlainObject>(value);
 
-    public double InnerHeight() => this.CallJSOfSameName<double>();
-    public JQueryPlainObject InnerHeight(string value) => this.CallJSOfSameNameAsWrapped(value);
-    public JQueryPlainObject InnerHeight(double value) => this.CallJSOfSameNameAsWrapped(value);
+    public double InnerHeight() => this.CallJS<double>();
+    public JQueryPlainObject InnerHeight(string value) => this.CallJS<JQueryPlainObject>(value);
+    public JQueryPlainObject InnerHeight(double value) => this.CallJS<JQueryPlainObject>(value);
 
-    public double InnerWidth() => this.CallJSOfSameName<double>();
-    public JQueryPlainObject InnerWidth(string value) => this.CallJSOfSameNameAsWrapped(value);
-    public JQueryPlainObject InnerWidth(double value) => this.CallJSOfSameNameAsWrapped(value);
+    public double InnerWidth() => this.CallJS<double>();
+    public JQueryPlainObject InnerWidth(string value) => this.CallJS<JQueryPlainObject>(value);
+    public JQueryPlainObject InnerWidth(double value) => this.CallJS<JQueryPlainObject>(value);
 
-    public double OuterHeight() => this.CallJSOfSameName<double>();
-    public JQueryPlainObject OuterHeight(string value) => this.CallJSOfSameNameAsWrapped(value);
-    public JQueryPlainObject OuterHeight(double value) => this.CallJSOfSameNameAsWrapped(value);
+    public double OuterHeight() => this.CallJS<double>();
+    public JQueryPlainObject OuterHeight(string value) => this.CallJS<JQueryPlainObject>(value);
+    public JQueryPlainObject OuterHeight(double value) => this.CallJS<JQueryPlainObject>(value);
 
-    public double OuterWidth() => this.CallJSOfSameName<double>();
-    public JQueryPlainObject OuterWidth(string value) => this.CallJSOfSameNameAsWrapped(value);
-    public JQueryPlainObject OuterWidth(double value) => this.CallJSOfSameNameAsWrapped(value);
+    public double OuterWidth() => this.CallJS<double>();
+    public JQueryPlainObject OuterWidth(string value) => this.CallJS<JQueryPlainObject>(value);
+    public JQueryPlainObject OuterWidth(double value) => this.CallJS<JQueryPlainObject>(value);
 
-    public double ScrollLeft() => this.CallJSOfSameName<double>();
-    public JQueryPlainObject ScrollLeft(double value) => this.CallJSOfSameNameAsWrapped(value);
+    public double ScrollLeft() => this.CallJS<double>();
+    public JQueryPlainObject ScrollLeft(double value) => this.CallJS<JQueryPlainObject>(value);
 
-    public double ScrollTop() => this.CallJSOfSameName<double>();
-    public JQueryPlainObject ScrollTop(double value) => this.CallJSOfSameNameAsWrapped(value);
+    public double ScrollTop() => this.CallJS<double>();
+    public JQueryPlainObject ScrollTop(double value) => this.CallJS<JQueryPlainObject>(value);
 
     // TODO: Position Getter, returns X/Y object "coosrdinates" https://api.jquery.com/position/
     // TODO: Offset, takes cordinates object https://api.jquery.com/offset/
@@ -167,91 +173,120 @@ public class JQueryPlainObject : IJSObjectWrapper<JQueryPlainObject>, IJQueryCon
 
     #region Instance Properties - https://api.jquery.com/category/properties/jquery-object-instance-properties/
 
-    public double Length => this.GetPropertyOfSameName<double>();
-    public string JQueryVersion => this.GetPropertyOfSameName<string>(propertyName: "jquery");
+    public double Length => this.GetJSProperty<double>();
+    public string JQueryVersion => this.GetJSProperty<string>("jquery");
+
+    #endregion
+
+    #region DOM Element Methods - https://api.jquery.com/get/
+
+    /// <summary>
+    /// <para>Retrieve one of the underlying native DOM elements wrapped by this jQuery collection, as a <see cref="JSObject"/>.</para>
+    /// <para>Mirrors jQuery's <c>.get(index)</c>: <c>var el = jq.Get(0);</c></para>
+    /// </summary>
+    /// <param name="index">Zero-based index of the element to retrieve. Negative indices are counted from the end, matching jQuery's semantics.</param>
+    /// <returns>The underlying DOM element as <see cref="JSObject"/>; may be <c>null</c> if the index is out of range.</returns>
+    public JSObject Get(int index) => this.CallJS<JSObject>(index);
+
+    /// <summary>
+    /// <para>Retrieve all underlying native DOM elements wrapped by this jQuery collection as an array of <see cref="JSObject"/>.</para>
+    /// <para>Mirrors jQuery's parameterless <c>.get()</c>: <c>var elements = jq.Get();</c></para>
+    /// </summary>
+    /// <returns>An array of <see cref="JSObject"/> references for each element in the collection.</returns>
+    public JSObject[] Get()
+    {
+        // jQuery .get() (no args) returns a native JS array of elements.
+        // Use the shimmed MarshalAsArrayOfObjects helper to marshal that array
+        // into a JSObject[] on the .NET side.
+        var jsArray = this.CallJS<JSObject[]>();
+        // TODO: Fails for JSObject[] array: GlobalJS.Console.Log("jsArray", jsArray);
+        return jsArray;
+            //jsArray.Cast<JSObject>().ToArray();
+        //  jsArray.MarshalAsArrayOfObjects();
+    }
 
     #endregion
 
     #region Class Attributes - https://api.jquery.com/category/manipulation/class-attribute/
     // CONSIDER: Validating that className parameters don't start with "." since this is a pitfall
-    public bool HasClass(string className) => this.CallJSOfSameName<bool>(className);
+    public bool HasClass(string className) => this.CallJS<bool>(className);
     // NOTE: The native method only takes a single item or a seperate overload that takes an array, which is why we need to pass as `new object []`.  This is different from other methods that take one to many seperate params.
-    // WORKS but doesn't match interface exactly: public JQueryPlainObject AddClass(string className, params string[] classNames) => this.CallJSOfSameNameAsWrapped( new object[] { Params.PrependToArray(className, ref classNames) } ); // new object[] { Params.Merge(className, classNames) });
-    public JQueryPlainObject AddClass(string className) => this.CallJSOfSameNameAsWrapped(className);
-    public JQueryPlainObject AddClass(string[] classNames) => this.CallJSOfSameNameAsWrapped(new object[] { classNames }); // Have to wrap in an extra array because javacsript .apply() will split the array into seperate params
-    public JQueryPlainObject RemoveClass(string className) => this.CallJSOfSameNameAsWrapped(className);
-    public JQueryPlainObject RemoveClass(string[] classNames) => this.CallJSOfSameNameAsWrapped(new object[] { classNames });
-    public JQueryPlainObject ToggleClass(string className, bool? state = null) => this.CallJSOfSameNameAsWrapped(className, state);
-    public JQueryPlainObject ToggleClass(string[] classNames, bool? state = null) => this.CallJSOfSameNameAsWrapped(classNames, state);
+    // WORKS but doesn't match interface exactly: public JQueryPlainObject AddClass(string className, params string[] classNames) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(SerratedJQParams.Prepend(className, classNames)));
+    public JQueryPlainObject AddClass(string className) => this.CallJS<JQueryPlainObject>(className);
+    public JQueryPlainObject AddClass(string[] classNames) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(new object[] { classNames })); // Have to wrap in an extra array because javacsript .apply() will split the array into seperate params
+    public JQueryPlainObject RemoveClass(string className) => this.CallJS<JQueryPlainObject>(className);
+    public JQueryPlainObject RemoveClass(string[] classNames) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(new object[] { classNames }));
+    public JQueryPlainObject ToggleClass(string className, bool? state = null) => this.CallJS<JQueryPlainObject>(className, state);
+    public JQueryPlainObject ToggleClass(string[] classNames, bool? state = null) => this.CallJS<JQueryPlainObject>(classNames, state);
 
     #endregion
     #region Copying - https://api.jquery.com/category/manipulation/copying/
 
-    public JQueryPlainObject Clone() => this.CallJSOfSameNameAsWrapped();
+    public JQueryPlainObject Clone() => this.CallJS<JQueryPlainObject>();
     // TODO: Impkement other overloads
 
     #endregion
     #region DOM Insertion, Around, and Removal - https://api.jquery.com/category/manipulation/dom-insertion-around/
 
-    public JQueryPlainObject Unwrap(string selector = null) => this.CallJSOfSameNameAsWrapped(selector);
-    public JQueryPlainObject Wrap(string htmlOrSelector) => this.CallJSOfSameNameAsWrapped(htmlOrSelector);
-    public JQueryPlainObject Wrap(JQueryPlainObject jqObject) => this.CallJSOfSameNameAsWrapped(jqObject);
-    public JQueryPlainObject WrapAll(string htmlOrSelector) => this.CallJSOfSameNameAsWrapped(htmlOrSelector);
-    public JQueryPlainObject WrapAll(JQueryPlainObject jqObject) => this.CallJSOfSameNameAsWrapped(jqObject);
-    public JQueryPlainObject WrapInner(string htmlOrSelector) => this.CallJSOfSameNameAsWrapped(htmlOrSelector);
+    public JQueryPlainObject Unwrap(string selector = null) => this.CallJS<JQueryPlainObject>(selector);
+    public JQueryPlainObject Wrap(string htmlOrSelector) => this.CallJS<JQueryPlainObject>(htmlOrSelector);
+    public JQueryPlainObject Wrap(JQueryPlainObject jqObject) => this.CallJS<JQueryPlainObject>(jqObject);
+    public JQueryPlainObject WrapAll(string htmlOrSelector) => this.CallJS<JQueryPlainObject>(htmlOrSelector);
+    public JQueryPlainObject WrapAll(JQueryPlainObject jqObject) => this.CallJS<JQueryPlainObject>(jqObject);
+    public JQueryPlainObject WrapInner(string htmlOrSelector) => this.CallJS<JQueryPlainObject>(htmlOrSelector);
 
     // Only works correctly if passed HTMLElement. When passed JQ object created form our ParseHtml, it inserts only into one parent
-    //public JQueryObject WrapInner(JQueryObject jqObject) => this.CallJSOfSameNameAsWrapped(jqObject);
+    //public JQueryObject WrapInner(JQueryObject jqObject) => this.CallJS<JQueryPlainObject>(jqObject);
 
     #endregion
     #region DOM Insertion, Inside - https://api.jquery.com/category/manipulation/dom-insertion-inside/
 
-    public JQueryPlainObject Append(string html, params string[] htmls) => this.CallJSOfSameNameAsWrapped(Params.Merge(html, htmls));
-    public JQueryPlainObject Append(string html) => this.CallJSOfSameNameAsWrapped(html);
+    public JQueryPlainObject Append(string html, params string[] htmls) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(SerratedJQParams.Merge(html, htmls)));
+    public JQueryPlainObject Append(string html) => this.CallJS<JQueryPlainObject>(html);
     // TODO: Follow this pattern for implementing other methods that take JQuery's "content" params that support both JQuery objects and HtmlElement objects
-    public JQueryPlainObject Append(IJQueryContentParameter contentObject, params IJQueryContentParameter[] contentObjects) => this.CallJSOfSameNameAsWrapped(Params.PrependToArray(contentObject, ref contentObjects));
-    //public JQueryPlainObject Append(HtmlElement html) => this.CallJSOfSameNameAsWrapped(html);
-    //public JQueryPlainObject Append(JQueryPlainObject jqObject, params JQueryPlainObject[] jqObjects) => this.CallJSOfSameNameAsWrapped(Params.PrependToArray(jqObject, ref jqObjects));
-    public JQueryPlainObject AppendTo(string htmlOrSelector) => this.CallJSOfSameNameAsWrapped(htmlOrSelector);
-    public JQueryPlainObject AppendTo(JQueryPlainObject jqObject) => this.CallJSOfSameNameAsWrapped(jqObject);
-    public JQueryPlainObject Prepend(string html, params string[] htmls) => this.CallJSOfSameNameAsWrapped(Params.Merge(html, htmls));
-    public JQueryPlainObject Prepend(HtmlElement html) => this.CallJSOfSameNameAsWrapped(html);
-    public JQueryPlainObject Prepend(JQueryPlainObject jqObject, params JQueryPlainObject[] jqObjects) => this.CallJSOfSameNameAsWrapped(Params.Merge(jqObject, jqObjects));
-    public JQueryPlainObject PrependTo(string htmlOrSelector) => this.CallJSOfSameNameAsWrapped(htmlOrSelector);
-    public JQueryPlainObject PrependTo(JQueryPlainObject jqObject) => this.CallJSOfSameNameAsWrapped(jqObject);
+    public JQueryPlainObject Append(IJQueryContentParameter contentObject, params IJQueryContentParameter[] contentObjects) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(SerratedJQParams.Prepend(contentObject, contentObjects)));
+    //public JQueryPlainObject Append(HtmlElement html) => this.CallJS<JQueryPlainObject>(html);
+    //public JQueryPlainObject Append(JQueryPlainObject jqObject, params JQueryPlainObject[] jqObjects) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(SerratedJQParams.Prepend(jqObject, jqObjects)));
+    public JQueryPlainObject AppendTo(string htmlOrSelector) => this.CallJS<JQueryPlainObject>(htmlOrSelector);
+    public JQueryPlainObject AppendTo(JQueryPlainObject jqObject) => this.CallJS<JQueryPlainObject>(jqObject);
+    public JQueryPlainObject Prepend(string html, params string[] htmls) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(SerratedJQParams.Merge(html, htmls)));
+    public JQueryPlainObject Prepend(HtmlElement html) => this.CallJS<JQueryPlainObject>(html);
+    public JQueryPlainObject Prepend(JQueryPlainObject jqObject, params JQueryPlainObject[] jqObjects) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(SerratedJQParams.Merge(jqObject, jqObjects)));
+    public JQueryPlainObject PrependTo(string htmlOrSelector) => this.CallJS<JQueryPlainObject>(htmlOrSelector);
+    public JQueryPlainObject PrependTo(JQueryPlainObject jqObject) => this.CallJS<JQueryPlainObject>(jqObject);
 
-    public string Html() => this.CallJSOfSameName<string>();
-    public JQueryPlainObject Html(string htmlString) => this.CallJSOfSameNameAsWrapped(htmlString);
+    public string Html() => this.CallJS<string>();
+    public JQueryPlainObject Html(string htmlString) => this.CallJS<JQueryPlainObject>(htmlString);
 
-    public string Text() => this.CallJSOfSameName<string>();
-    public JQueryPlainObject Text(string text) => this.CallJSOfSameNameAsWrapped(text);
+    public string Text() => this.CallJS<string>();
+    public JQueryPlainObject Text(string text) => this.CallJS<JQueryPlainObject>(text);
 
     #endregion
     #region DOM Insertion, Outside - https://api.jquery.com/category/manipulation/dom-insertion-outside/
 
-    public JQueryPlainObject After(string html, params string[] htmls) => this.CallJSOfSameNameAsWrapped(Params.Merge(html, htmls));
-    public JQueryPlainObject After(JQueryPlainObject jqObject, params JQueryPlainObject[] jqObjects) => this.CallJSOfSameNameAsWrapped(Params.Merge(jqObject, jqObjects));
-    public JQueryPlainObject Before(string html, params string[] htmls) => this.CallJSOfSameNameAsWrapped(Params.Merge(html, htmls));
-    public JQueryPlainObject Before(JQueryPlainObject jqObject, params JQueryPlainObject[] jqObjects) => this.CallJSOfSameNameAsWrapped(Params.Merge(jqObject, jqObjects));
-    public JQueryPlainObject InsertAfter(string htmlOrSelector) => this.CallJSOfSameNameAsWrapped(htmlOrSelector);
-    public JQueryPlainObject InsertAfter(JQueryPlainObject jqObject) => this.CallJSOfSameNameAsWrapped(jqObject);
-    public JQueryPlainObject InsertBefore(string htmlOrSelector) => this.CallJSOfSameNameAsWrapped(htmlOrSelector);
-    public JQueryPlainObject InsertBefore(JQueryPlainObject jqObject) => this.CallJSOfSameNameAsWrapped(jqObject);
+    public JQueryPlainObject After(string html, params string[] htmls) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(SerratedJQParams.Merge(html, htmls)));
+    public JQueryPlainObject After(JQueryPlainObject jqObject, params JQueryPlainObject[] jqObjects) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(SerratedJQParams.Merge(jqObject, jqObjects)));
+    public JQueryPlainObject Before(string html, params string[] htmls) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(SerratedJQParams.Merge(html, htmls)));
+    public JQueryPlainObject Before(JQueryPlainObject jqObject, params JQueryPlainObject[] jqObjects) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(SerratedJQParams.Merge(jqObject, jqObjects)));
+    public JQueryPlainObject InsertAfter(string htmlOrSelector) => this.CallJS<JQueryPlainObject>(htmlOrSelector);
+    public JQueryPlainObject InsertAfter(JQueryPlainObject jqObject) => this.CallJS<JQueryPlainObject>(jqObject);
+    public JQueryPlainObject InsertBefore(string htmlOrSelector) => this.CallJS<JQueryPlainObject>(htmlOrSelector);
+    public JQueryPlainObject InsertBefore(JQueryPlainObject jqObject) => this.CallJS<JQueryPlainObject>(jqObject);
 
     #endregion
     #region DOM Removal - https://api.jquery.com/category/manipulation/dom-removal/
 
-    public JQueryPlainObject Detach(string selector = null) => this.CallJSOfSameNameAsWrapped(selector);
-    public JQueryPlainObject Empty() => this.CallJSOfSameNameAsWrapped();
-    public JQueryPlainObject Remove(string selector = null) => this.CallJSOfSameNameAsWrapped(selector);
+    public JQueryPlainObject Detach(string selector = null) => this.CallJS<JQueryPlainObject>(selector);
+    public JQueryPlainObject Empty() => this.CallJS<JQueryPlainObject>();
+    public JQueryPlainObject Remove(string selector = null) => this.CallJS<JQueryPlainObject>(selector);
 
     #endregion
     #region DOM Replacement - https://api.jquery.com/category/manipulation/dom-replacement/
     // TODO: Write unit tests
-    //public JQueryPlainObject ReplaceAll(string htmlOrSelector) => this.CallJSOfSameNameAsWrapped(htmlOrSelector);
-    //public JQueryPlainObject ReplaceAll(JQueryPlainObject jqObject) => this.CallJSOfSameNameAsWrapped(jqObject);
-    public JQueryPlainObject ReplaceWith(string htmlString) => this.CallJSOfSameNameAsWrapped(htmlString);
-    public JQueryPlainObject ReplaceWith(IJQueryContentParameter contentObject) => this.CallJSOfSameNameAsWrapped(contentObject);
+    //public JQueryPlainObject ReplaceAll(string htmlOrSelector) => this.CallJS<JQueryPlainObject>(htmlOrSelector);
+    //public JQueryPlainObject ReplaceAll(JQueryPlainObject jqObject) => this.CallJS<JQueryPlainObject>(jqObject);
+    public JQueryPlainObject ReplaceWith(string htmlString) => this.CallJS<JQueryPlainObject>(htmlString);
+    public JQueryPlainObject ReplaceWith(IJQueryContentParameter contentObject) => this.CallJS<JQueryPlainObject>(contentObject);
 
     #endregion
 
@@ -346,7 +381,7 @@ public class JQueryPlainObject : IJSObjectWrapper<JQueryPlainObject>, IJQueryCon
                {
                    //Console.WriteLine("Event Encoded: " + eventEncoded);
                    // unpack the single ArrayObject into it's individual elements, wrapping them as JQueryObjects
-                   var replacements = HelpersJS.GetArrayObjectItems(arrayObject).Select(j => new JQueryPlainObject(j)).ToList();
+                   var replacements = SerratedSharp.SerratedJSInterop.HelpersJS.GetArrayObjectItems(arrayObject).Select(j => new JQueryPlainObject(j)).ToList();
                    // Deserialize the eventEncoded JSON string, and restore the native JS objects
                    dynamic eventData = EncodedEventToDynamic(eventEncoded, replacements);
 
@@ -449,17 +484,17 @@ public class JQueryPlainObject : IJSObjectWrapper<JQueryPlainObject>, IJQueryCon
     // Incomplete - Not all members implemented
 
     // .trigger( eventType [, extraParameters ] )
-    public JQueryPlainObject Trigger(string eventType, params object[] extraParameters) => this.CallJSOfSameNameAsWrapped(Params.Merge(eventType, new object[] { extraParameters }));
+    public JQueryPlainObject Trigger(string eventType, params object[] extraParameters) => this.CallJS<JQueryPlainObject>(SerratedJS.Params(SerratedJQParams.Merge(eventType, extraParameters)));
 
     #endregion
     #region Data - https://api.jquery.com/category/data/
 
-    public T Data<T>(string key) => this.CallJSOfSameName<T>(key);
-    public JQueryPlainObject Data(string key, object value) => this.CallJSOfSameNameAsWrapped(key, value);
+    public T Data<T>(string key) => this.CallJS<T>(key);
+    public JQueryPlainObject Data(string key, object value) => this.CallJS<JQueryPlainObject>(key, value);
     /// <summary>
     /// Calls JQuery.Data() returning the entire data object as a JSObject reference.  Use JSObject.GetPropertyAs* methods to access properties or pass reference to GlobalJS.Console.Log(obj) to log entire object graph in browser console.
     /// </summary>
-    public JSObject DataAsJSObject() => this.CallJSOfSameName<JSObject>(funcName: "data");
+    public JSObject DataAsJSObject() => this.CallJS<JSObject>(funcName:"data");
 
     #endregion
 

--- a/SerratedJQLibrary/SerratedJQ/SerratedJQ.csproj
+++ b/SerratedJQLibrary/SerratedJQ/SerratedJQ.csproj
@@ -10,18 +10,18 @@
 
   <PropertyGroup>
 	  <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>SerratedSharp.SerratedJQ</RootNamespace>
     <PackageId>SerratedSharp.SerratedJQ</PackageId>
     <Authors>SerratedSharpSolutions</Authors>
     <Company>SerratedSharpSolutions</Company>
     <Description>A C# WebAssembly wrapper for jQuery, intended to enable implementation of client side logic in C# for a traditional web application such as ASP.NET MVC.  Provides the capability to read and manipulate the HTML DOM, create .NET event handlers subscribed to HTML DOM events, hold references to DOM elements from a .NET WebAssembly, and attach primitive data or managed object references to elements.  Intended for us in assemblies that leverage Uno.Wasm.Bootstrap for compilation to WebAssembly format, but does not require consumers to use the full Uno Platform.</Description>
     <Copyright>Copyright (c) SerratedSharpSolutions 2024</Copyright>
-    <PackageReleaseNotes>This version has been tested with Uno.Wasm.Bootstrap 8.0.3 and alternatively .NET 8 wasmbrowser under .NET Core 8.</PackageReleaseNotes>
+    <PackageReleaseNotes>This version has been tested with .NET 9 wasmbrowser under .NET Core 9.  Testing for Uno WASM is no longer occurring, but volunteers are sought.</PackageReleaseNotes>
     <PackageTags>WebAssembly, Uno, JQuery</PackageTags>
-	        <Version>0.1.9</Version>
-	<AssemblyVersion>0.1.9.0</AssemblyVersion>
-        <FileVersion>0.1.9.0</FileVersion>
+	        <Version>0.2.1</Version>
+	<AssemblyVersion>0.2.1.0</AssemblyVersion>
+        <FileVersion>0.2.1.0</FileVersion>
 	<PackageReadmeFile>readme.md</PackageReadmeFile>
 	<AssemblyName>SerratedSharp.SerratedJQ</AssemblyName>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -48,6 +48,11 @@
     <None Remove="Resources\**" />
   </ItemGroup>
 	
+  <PropertyGroup>
+    <SerratedJQScriptSourcePath>$(ProjectDir)wwwroot\SerratedJQ.js</SerratedJQScriptSourcePath>
+    <SerratedJQScriptWasmScriptsPath>$(ProjectDir)WasmScripts\SerratedJQ.js</SerratedJQScriptWasmScriptsPath>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Remove="WasmScripts\SerratedJQ.js" />
   </ItemGroup>
@@ -58,6 +63,11 @@
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </EmbeddedResource>
   </ItemGroup>
+
+  <Target Name="CopySerratedJQToWasmScripts" BeforeTargets="BeforeBuild" Condition="Exists('$(SerratedJQScriptSourcePath)')">
+    <MakeDir Directories="$(ProjectDir)WasmScripts" />
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(ProjectDir)CopySerratedJQToWasmScripts.ps1&quot; -SourcePath &quot;$(SerratedJQScriptSourcePath)&quot; -DestPath &quot;$(SerratedJQScriptWasmScriptsPath)&quot;" />
+  </Target>
 
   <ItemGroup>
 	 <None Include="readme.md" Pack="true" PackagePath="\" />
@@ -91,7 +101,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\JSInteropHelpers\JSInteropHelpers.csproj" />
+	  <!-- Use ProjectReference when building with SerratedJSInterop repo alongside (e.g. multi-root workspace). For package-only consumers, use PackageReference to SerratedSharp.SerratedJSInterop 0.3.1. -->
+	  <ProjectReference Include="..\..\..\SerratedJSInterop\SerratedJSInterop\SerratedJSInterop.csproj" Condition="Exists('..\..\..\SerratedJSInterop\SerratedJSInterop\SerratedJSInterop.csproj')" />
+	  <PackageReference Include="SerratedSharp.SerratedJSInterop" Version="0.3.2" Condition="!Exists('..\..\..\SerratedJSInterop\SerratedJSInterop\SerratedJSInterop.csproj')" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SerratedJQLibrary/SerratedJQ/SerratedJQModule.cs
+++ b/SerratedJQLibrary/SerratedJQ/SerratedJQModule.cs
@@ -1,8 +1,7 @@
-﻿
 using System;
 using System.Runtime.InteropServices.JavaScript;
 using System.Threading.Tasks;
-
+using SerratedSharp.SerratedJSInterop;
 
 namespace SerratedSharp.SerratedJQ
 {
@@ -10,13 +9,12 @@ namespace SerratedSharp.SerratedJQ
     public static class JSDeclarations
     {
         /// <summary>
-        /// Loads embedded JS scripts that this library's interop depends on. 
-        /// Leverages embedded RCL Static Web Assets embedded in this library, 
+        /// Loads embedded JS scripts that this library's interop depends on.
+        /// Leverages embedded RCL Static Web Assets embedded in this library,
         /// which are emitted into the consuming application during publish.
         /// Loaded with JSHost.ImportAsync()
         /// </summary>
         /// <param name="basePath">Base path if site, if not rooted at domain.</param>
-        /// <returns></returns>
         public static async Task LoadScriptsForWasmBrowser(string basePath = "")
         {
             await SerratedJQModule.ImportAsync(basePath);
@@ -29,30 +27,27 @@ namespace SerratedSharp.SerratedJQ
         /// <param name="url">Relative or absolute URL of jQuery library, such as "jquery-3.7.1.js" if it was in the root of the application.</param>
         public static async Task LoadJQuery(string url)
         {
-            await SerratedSharp.JSInteropHelpers.HelpersJS.LoadJQuery(url);
+            await SerratedJQModule.LoadJQuery(url);
         }
     }
-
 
     public static class SerratedJQModule
     {
         /// <summary>
-        /// Loads embedded JS scripts that this library's interop depends on. 
-        /// Leverages embedded RCL Static Web Assets embedded in this library, 
-        /// which are emitted into the consuming application during publish.
+        /// Loads embedded JS scripts that this library's interop depends on.
+        /// Loads SerratedJSInterop (dependency) first, then SerratedJQ.js.
         /// Loaded with JSHost.ImportAsync()
         /// This is typically needed for a WASM Browser project, but is not needed for a Uno.Wasm.Bootstrap project.
         /// </summary>
         /// <param name="basePath">Base path if site, if not rooted at domain.</param>
-        /// <param name="subPath">Sub path.  Default is "/_content/SerratedSharp.SerratedJQ/SerratedJQ.js" for loading Static Web Asset from Razor Class Library.  Provide alternate subpath to concatenate with basePath if loading from custom location.</param>        
+        /// <param name="subPath">Sub path.  Default is "/_content/SerratedSharp.SerratedJQ/SerratedJQ.js" for loading Static Web Asset from Razor Class Library.  Provide alternate subpath to concatenate with basePath if loading from custom location.</param>
         public static async Task ImportAsync(string basePath = "", string subPath = null)
         {
-            await JSInteropHelpers.JSInteropHelpersModule.ImportAsync(basePath);
+            await SerratedSharp.SerratedJSInterop.SerratedJSInteropModule.ImportAsync(basePath);
 
             string path = basePath.TrimEnd('/') +
                 (subPath ?? "/_content/SerratedSharp.SerratedJQ/SerratedJQ.js");
             await JSHost.ImportAsync("SerratedJQ", path);
-
         }
 
         /// <summary>
@@ -62,12 +57,28 @@ namespace SerratedSharp.SerratedJQ
         /// <param name="url">Relative or absolute URL of jQuery library, such as "jquery-3.7.1.js" if it was in the root of the application.</param>
         public static async Task LoadJQuery(string url)
         {
-            await SerratedSharp.JSInteropHelpers.HelpersJS.LoadJQuery(url);
+            if (AgnosticRuntime.IsUnoWasmBootstrapLoaded)
+                await LoadJQueryForUno.LoadJQuery(url);
+            else
+                await LoadJQueryForDotNet.LoadJQuery(url);
         }
-
     }
 
+    internal static partial class LoadJQueryForDotNet
+    {
+        private const string baseJSNamespace = "SerratedJQ.JQueryProxy";
+        private const string moduleName = "SerratedJQ";
 
+        [JSImport(baseJSNamespace + ".LoadJQuery", moduleName)] 
+        public static partial Task LoadJQuery(string url);
+    }
 
+    internal static partial class LoadJQueryForUno
+    {
+        private const string baseJSNamespace = "globalThis." + "SerratedJQ.JQueryProxy";
+
+        [JSImport(baseJSNamespace + ".LoadJQuery")]
+        public static partial Task LoadJQuery(string url);
+    }
 }
 

--- a/SerratedJQLibrary/SerratedJQ/WasmScripts/SerratedJQ.js
+++ b/SerratedJQLibrary/SerratedJQ/WasmScripts/SerratedJQ.js
@@ -1,4 +1,6 @@
-// TODO: Rename file to HelpersProxy
+define(() => {
+
+// TODO: Rename file to HelpersProxy.
 
 // This javascript declaration is an embedded resource, and is emitted client side by C# startup code at runtime.
 console.log("Declaring SerratedJQ Shims");
@@ -7,8 +9,7 @@ console.log("Declaring SerratedJQ Shims");
 //Module.getAssemblyExports("SerratedSharp.SerratedJQ")
 //    .then(module => globalThis.SerratedExports = module);
 
-define(() => {
-
+// TODO: Consider object literal notation instead of IIFE, and export as module
 var SerratedJQ = globalThis.SerratedJQ || {};
 (function (SerratedJQ) {
 
@@ -55,7 +56,7 @@ var SerratedJQ = globalThis.SerratedJQ || {};
                 }
                 return value;
             });
-            // TODO: If we don't find any replacements then send null and supress the unpack GetArrayObjectItems call on C# side(unnecesary interop call).
+            // TODO: If we don't find any replacements then send null and supress the unpack GetArrayObjectItems call on C# side(unnecessary interop call).
             action(eEncoded, e.type, new ArrayObject(replacements));
         }.bind(jsObject);
 
@@ -72,6 +73,14 @@ var SerratedJQ = globalThis.SerratedJQ || {};
 
     JQueryProxy.Check = function () { console.log("check"); }
 
+    JQueryProxy.LoadJQuery = function (relativeUrl) {
+        if (window.jQuery) {
+            return Promise.resolve();
+        } else {
+            return loadScript(relativeUrl);
+        }
+    };
+
     //JQueryProxy.Init = function () {
     //    globalThis.SerratedExports = await Module.getAssemblyExports("SerratedSharp.SerratedJQ");
     //}
@@ -83,6 +92,24 @@ var SerratedJQ = globalThis.SerratedJQ || {};
     }
 
     SerratedJQ.JQueryProxy = JQueryProxy; // add to parent namespace
+
+    // jQuery-specific: load jQuery from URL, or resolve immediately if already loaded
+    function loadScript(relativeUrl) {
+        return new Promise(function (resolve, reject) {
+            var script = document.createElement("script");
+            script.onload = resolve;
+            script.onerror = reject;
+            script.src = relativeUrl;
+            document.getElementsByTagName("head")[0].appendChild(script);
+        });
+    }
+    SerratedJQ.LoadJQuery = function (relativeUrl) {
+        if (window.jQuery) {
+            return Promise.resolve();
+        } else {
+            return loadScript(relativeUrl);
+        }
+    };
 
 })(SerratedJQ = globalThis.SerratedJQ || (globalThis.SerratedJQ = {}));
 

--- a/SerratedJQLibrary/SerratedJQ/readme.md
+++ b/SerratedJQLibrary/SerratedJQ/readme.md
@@ -72,7 +72,7 @@ var prods = JsonSerializer.Deserialize<List<ProductSalesModel>>(content);
 ## Installation
 
 ### Prerequisites  
-- SerratedSharp.SerratedJQ, SerratedSharp.JSInteropHelpers, NewtonSoft.Json
+- SerratedSharp.SerratedJQ, SerratedSharp.SerratedJSInterop, NewtonSoft.Json
 - A project either using the .NET 8 wasmbrowser project(`<Project Sdk="Microsoft.NET.Sdk.WebAssembly">`) or Uno.Wasm.Bootstrap
 - .NET Core 8
 
@@ -135,7 +135,7 @@ Video: https://www.youtube.com/watch?v=h7c05KnybrQ
 	<PackageReference Include="Uno.Foundation.Runtime.WebAssembly" Version="5.0.48" />
 	<PackageReference Include="Uno.Wasm.Bootstrap" Version="8.0.4" />
 	<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="8.0.4" />
-	<PackageReference Include="SerratedSharp.JSInteropHelpers" Version="0.1.6" />
+	<PackageReference Include="SerratedSharp.SerratedJSInterop" Version="0.3.1" />
 	<PackageReference Include="SerratedSharp.SerratedJQ" Version="0.1.6" />
 </ItemGroup>
 <PropertyGroup>	
@@ -295,7 +295,7 @@ JQuery's design simplifies the amount of interop needed to enable HTML DOM manip
 ### 0.1.6
 
 > [!IMPORTANT] 
-> Breaking Change: Loading and initialization is slightly different due to necesary changes to support both .NET 8 wasmbrowser and Uno.Wasm.Bootstrap.
+> Breaking Change: Loading and initialization is slightly different due to necessary changes to support both .NET 8 wasmbrowser and Uno.Wasm.Bootstrap.
 > Consumers using Uno.Wasm.Bootstrap no longer need to call `JSDeclarations.LoadScripts`, as the JS declarations are now imported automatically using AMD modules supported through Uno's support of scripts embedded in WasmScripts.  These typically are generated as part of the package during publish, and automatically imported at runtime when Uno.Wasm.Bootstrap loads.
 
 See [Uno.Wasm.Bootstrap Project](#unowasmbootstrap-project) for updated initialization.

--- a/SerratedJQLibrary/SerratedJQ/wwwroot/SerratedJQ.js
+++ b/SerratedJQLibrary/SerratedJQ/wwwroot/SerratedJQ.js
@@ -1,4 +1,4 @@
-// TODO: Rename file to HelpersProxy
+// TODO: Rename file to HelpersProxy.
 
 // This javascript declaration is an embedded resource, and is emitted client side by C# startup code at runtime.
 console.log("Declaring SerratedJQ Shims");
@@ -54,7 +54,7 @@ var SerratedJQ = globalThis.SerratedJQ || {};
                 }
                 return value;
             });
-            // TODO: If we don't find any replacements then send null and supress the unpack GetArrayObjectItems call on C# side(unnecesary interop call).
+            // TODO: If we don't find any replacements then send null and supress the unpack GetArrayObjectItems call on C# side(unnecessary interop call).
             action(eEncoded, e.type, new ArrayObject(replacements));
         }.bind(jsObject);
 
@@ -71,6 +71,14 @@ var SerratedJQ = globalThis.SerratedJQ || {};
 
     JQueryProxy.Check = function () { console.log("check"); }
 
+    JQueryProxy.LoadJQuery = function (relativeUrl) {
+        if (window.jQuery) {
+            return Promise.resolve();
+        } else {
+            return loadScript(relativeUrl);
+        }
+    };
+
     //JQueryProxy.Init = function () {
     //    globalThis.SerratedExports = await Module.getAssemblyExports("SerratedSharp.SerratedJQ");
     //}
@@ -83,6 +91,25 @@ var SerratedJQ = globalThis.SerratedJQ || {};
 
     SerratedJQ.JQueryProxy = JQueryProxy; // add to parent namespace
 
+    // jQuery-specific: load jQuery from URL, or resolve immediately if already loaded
+    function loadScript(relativeUrl) {
+        return new Promise(function (resolve, reject) {
+            var script = document.createElement("script");
+            script.onload = resolve;
+            script.onerror = reject;
+            script.src = relativeUrl;
+            document.getElementsByTagName("head")[0].appendChild(script);
+        });
+    }
+    SerratedJQ.LoadJQuery = function (relativeUrl) {
+        if (window.jQuery) {
+            return Promise.resolve();
+        } else {
+            return loadScript(relativeUrl);
+        }
+    };
+
 })(SerratedJQ = globalThis.SerratedJQ || (globalThis.SerratedJQ = {}));
 
 export { SerratedJQ };
+export const LoadJQuery = SerratedJQ.LoadJQuery;

--- a/SerratedJQLibrary/Tests.NetWasmBrowser/Program.cs
+++ b/SerratedJQLibrary/Tests.NetWasmBrowser/Program.cs
@@ -1,4 +1,3 @@
-using SerratedSharp.JSInteropHelpers;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using System.Diagnostics;

--- a/SerratedJQLibrary/Tests.NetWasmBrowser/Tests.NetWasmBrowser.csproj
+++ b/SerratedJQLibrary/Tests.NetWasmBrowser/Tests.NetWasmBrowser.csproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WebAssembly">
+<Project Sdk="Microsoft.NET.Sdk.WebAssembly">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\JSInteropHelpers\JSInteropHelpers.csproj" />
     <ProjectReference Include="..\SerratedJQ\SerratedJQ.csproj" />
     <ProjectReference Include="..\Tests.Shared\Tests.Shared.csproj" />
   </ItemGroup>

--- a/SerratedJQLibrary/Tests.Shared/ClassAttributes.cs
+++ b/SerratedJQLibrary/Tests.Shared/ClassAttributes.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Shared/Copying.cs
+++ b/SerratedJQLibrary/Tests.Shared/Copying.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Shared/Data.cs
+++ b/SerratedJQLibrary/Tests.Shared/Data.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
@@ -38,8 +38,13 @@ public partial class TestsContainer
         {
             JQueryPlainObject stubs = StubHtmlIntoTestContainer(1);
             stubs.Data("one", "uno");
-
             JSObject obj = tc.Find(".a").DataAsJSObject();
+            var jqObj = tc.Find(".a");
+            // Test of JS obj is null/undefined
+            //jqObj.JSObject.GetPropertyAsJSObject("");
+            obj = jqObj.DataAsJSObject();
+
+
             GlobalJS.Console.Log("Data() test: ", obj);
             string val = obj.GetPropertyAsString("one");
 

--- a/SerratedJQLibrary/Tests.Shared/Events.cs
+++ b/SerratedJQLibrary/Tests.Shared/Events.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Shared/GeneralAttributes.cs
+++ b/SerratedJQLibrary/Tests.Shared/GeneralAttributes.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using System.Linq;

--- a/SerratedJQLibrary/Tests.Shared/Get.cs
+++ b/SerratedJQLibrary/Tests.Shared/Get.cs
@@ -1,0 +1,51 @@
+using SerratedSharp.SerratedJSInterop;
+using SerratedSharp.SerratedJQ.Plain;
+using System.Runtime.InteropServices.JavaScript;
+using Wasm;
+
+namespace Tests.Wasm;
+
+public partial class TestsContainer
+{
+    // Tests for JQueryPlainObject.Get() / Get(int) – mirrors jQuery .get()
+
+    public class Get_AllElements_AsJSObjects : JQTest
+    {
+        public override void Run()
+        {
+            // Arrange: stub three elements into the shared test container
+            JQueryPlainObject stubs = StubHtmlIntoTestContainer(3);
+            result = tc.Children();
+
+            // Act: retrieve the underlying native elements as JSObject[]
+            JSObject[] elements = result.Get();
+
+            // Assert: three elements with classes "a", "b", "c" in order
+            Assert(elements.Length == 3, "Get() should return three elements for three stubs");
+            Assert(elements[0].GetJSProperty<string>("className") == "a", "First element should have class 'a'");
+            Assert(elements[1].GetJSProperty<string>("className") == "b", "Second element should have class 'b'");
+            Assert(elements[2].GetJSProperty<string>("className") == "c", "Third element should have class 'c'");
+        }
+    }
+
+    public class Get_ByIndex_AsJSObject : JQTest
+    {
+        public override void Run()
+        {
+            // Arrange: stub three elements into the shared test container
+            JQueryPlainObject stubs = StubHtmlIntoTestContainer(3);
+            result = tc.Children();
+
+            // Act: retrieve individual underlying native elements by index
+            JSObject first = result.Get(0);
+            JSObject second = result.Get(1);
+            JSObject third = result.Get(2);
+
+            // Assert: index-based access matches expected classes "a", "b", "c"
+            Assert(first.GetJSProperty<string>("className") == "a", "Get(0) should return element with class 'a'");
+            Assert(second.GetJSProperty<string>("className") == "b", "Get(1) should return element with class 'b'");
+            Assert(third.GetJSProperty<string>("className") == "c", "Get(2) should return element with class 'c'");
+        }
+    }
+}
+

--- a/SerratedJQLibrary/Tests.Shared/InsertionAround.cs
+++ b/SerratedJQLibrary/Tests.Shared/InsertionAround.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Shared/InsertionInside.cs
+++ b/SerratedJQLibrary/Tests.Shared/InsertionInside.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ;
 using SerratedSharp.SerratedJQ.Plain;
 using System;

--- a/SerratedJQLibrary/Tests.Shared/InsertionOutside.cs
+++ b/SerratedJQLibrary/Tests.Shared/InsertionOutside.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/SerratedJQLibrary/Tests.Shared/InstanceProperties.cs
+++ b/SerratedJQLibrary/Tests.Shared/InstanceProperties.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using System.Runtime.InteropServices.JavaScript;
@@ -36,22 +36,45 @@ public partial class TestsContainer
             // Initialize empty test container
             StubHtmlIntoTestContainer(0);
 
-            var document = JSHost.GlobalThis.GetPropertyAsJSObject("document");
-            var parentDiv = (JSObject)JSInstanceProxy.FuncByNameAsObject(document, "createElement", new object[] { "div" });
-            var childDiv = (JSObject)JSInstanceProxy.FuncByNameAsObject(document, "createElement", new object[] { "div" });
-            JSInstanceProxy.SetPropertyByName(parentDiv, "id", "parent-id");
-            JSInstanceProxy.SetPropertyByName(childDiv, "id", "child-id");
-            _ = JSInstanceProxy.FuncByNameAsObject(parentDiv, "appendChild", new object[] { childDiv });
+            var document = (JSObject)JSHost.GlobalThis.GetPropertyAsJSObject("document");
+            var parentDiv = document.CallJS<JSObject>(funcName: "createElement", "div");
+            var childDiv = document.CallJS<JSObject>(funcName: "createElement", "div");
+            parentDiv.SetJSProperty("parent-id", "id");
+            childDiv.SetJSProperty("child-id", "id");
+            _ = parentDiv.CallJS<JSObject>(funcName: "appendChild", childDiv);
 
             // Append parentDiv into test container using jQuery .append() (valid method on tc.JSObject)
-            _ = JSInstanceProxy.FuncByNameAsObject(tc.JSObject, "append", new object[] { parentDiv });
+            _ = tc.JSObject.CallJS<JSObject>(funcName: "append", parentDiv);
 
             // Act: fetch parentElement wrapped
-            var parentWrapped = JSImportInstanceHelpers.GetPropertyOfSameNameAsWrapped<DomElementProxy>(childDiv, propertyName: "ParentElement");
+            var parentWrapped = childDiv.GetJSProperty<DomElementProxy>("ParentElement");
 
             // Assert
             Assert(parentWrapped != null, "Wrapped parent element is null");
             Assert(parentWrapped.Id == "parent-id", "parentElement did not wrap correctly or wrong element returned");
+        }
+    }
+
+    // New test: exercise extension method GetJSProperty<W>
+    public class InstanceProperties_Extension_AsWrapped_ParentElement : JQTest
+    {
+        public override void Run()
+        {
+            StubHtmlIntoTestContainer(0);
+            var document = (JSObject)JSHost.GlobalThis.GetPropertyAsJSObject("document");
+            var parentDiv = document.CallJS<JSObject>(funcName: "createElement", "div");
+            var childDiv = document.CallJS<JSObject>(funcName: "createElement", "div");
+            parentDiv.SetJSProperty("ext-parent-id", "id");
+            childDiv.SetJSProperty("ext-child-id", "id");
+            _ = parentDiv.CallJS<JSObject>(funcName: "appendChild", childDiv);
+            _ = tc.JSObject.CallJS<JSObject>(funcName: "append", parentDiv);
+
+            // Wrap childDom as proxy to call extension
+            var childProxy = new DomElementProxy(childDiv);
+            var parentWrapped = childProxy.GetJSProperty<DomElementProxy>("ParentElement");
+
+            Assert(parentWrapped != null, "Extension wrapped parent element is null");
+            Assert(parentWrapped.Id == "ext-parent-id", "Extension parentElement did not wrap correctly or wrong element returned");
         }
     }
 }

--- a/SerratedJQLibrary/Tests.Shared/MiscTraversal.cs
+++ b/SerratedJQLibrary/Tests.Shared/MiscTraversal.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Shared/Removal.cs
+++ b/SerratedJQLibrary/Tests.Shared/Removal.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Shared/Replacement.cs
+++ b/SerratedJQLibrary/Tests.Shared/Replacement.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Shared/Setters.cs
+++ b/SerratedJQLibrary/Tests.Shared/Setters.cs
@@ -1,5 +1,5 @@
 using System.Runtime.InteropServices.JavaScript;
-using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using Wasm;
 
@@ -7,7 +7,7 @@ namespace Tests.Wasm;
 
 public partial class TestsContainer
 {
-    // Minimal DOM element wrapper to exercise GetProperty/SetProperty CallerMemberName helpers
+    // Minimal DOM element wrapper to exercise GetJSProperty/SetJSProperty CallerMemberName helpers
     private class DomElementProxy : IJSObjectWrapper<DomElementProxy>
     {
         public JSObject JSObject { get; }
@@ -16,20 +16,20 @@ public partial class TestsContainer
 
         public string Id
         {
-            get => JSImportInstanceHelpers.GetPropertyOfSameName<string>(JSObject);
-            set => JSImportInstanceHelpers.SetPropertyOfSameName(JSObject, value);
+            get => this.GetJSProperty<string>();
+            set => this.SetJSProperty(value);
         }
 
         public string Title
         {
-            get => JSImportInstanceHelpers.GetPropertyOfSameName<string>(JSObject);
-            set => JSImportInstanceHelpers.SetPropertyOfSameName(JSObject, value);
+            get => this.GetJSProperty<string>();
+            set => this.SetJSProperty(value);
         }
 
         public string TextContent
         {
-            get => JSImportInstanceHelpers.GetPropertyOfSameName<string>(JSObject);
-            set => JSImportInstanceHelpers.SetPropertyOfSameName(JSObject, value);
+            get => this.GetJSProperty<string>();
+            set => this.SetJSProperty(value);
         }
     }
 
@@ -38,10 +38,10 @@ public partial class TestsContainer
         public override void Run()
         {
             // Arrange: create a new <div> and append to body
-            var document = JSHost.GlobalThis.GetPropertyAsJSObject("document");
-            var body = (JSObject)JSInstanceProxy.PropertyByNameToObject(document, "body");
-            var div = (JSObject)JSInstanceProxy.FuncByNameAsObject(document, "createElement", new object[] { "div" });
-            _ = JSInstanceProxy.FuncByNameAsObject(body, "appendChild", new object[] { div });
+            var document = (JSObject)JSHost.GlobalThis.GetPropertyAsJSObject("document");
+            var body = document.GetJSProperty<JSObject>("body");
+            var div = document.CallJS<JSObject>(funcName: "createElement", "div");
+            _ = body.CallJS<JSObject>(funcName: "appendChild", div);
 
             var el = new DomElementProxy(div);
 
@@ -55,7 +55,7 @@ public partial class TestsContainer
             Assert(el.Title == "setter-test-title", "Title was not set via setter");
             Assert(el.TextContent == "setter-test-text", "TextContent was not set via setter");
 
-            var byId = (JSObject)JSInstanceProxy.FuncByNameAsObject(document, "getElementById", new object[] { "setter-test-id" });
+            var byId = document.CallJS<JSObject>(funcName: "getElementById", "setter-test-id");
             Assert(byId != null, "getElementById returned null");
         }
     }

--- a/SerratedJQLibrary/Tests.Shared/StyleProperties.cs
+++ b/SerratedJQLibrary/Tests.Shared/StyleProperties.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Shared/TestOrchestrator.cs
+++ b/SerratedJQLibrary/Tests.Shared/TestOrchestrator.cs
@@ -1,13 +1,14 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.InteropServices.JavaScript;
 using System.Threading;
 using System.Threading.Tasks;
-using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 
-//using SerratedSharp.JSInteropHelpers;
+//using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using Tests.Wasm;
 
@@ -75,11 +76,19 @@ public class TestOrchestrator
                 test.BeginTest(out status);
                 test.Run();
             }
-            catch (Exception ex)
+            catch (Exception ex) // Important: JSException often doesn't include stack in Message
             {
                 exc = ex;
             }
-            test.EndTest(status, exc);
+            try
+            {
+                test.EndTest(status, exc);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Exception in EndTest: " + ex);
+            }
+
             ++i;
         }
     }
@@ -137,16 +146,21 @@ public abstract class JQTest : IJQTest
         }
         else
         {
-            Console.WriteLine(exc);
+            string exMessage = exc.ToString();
+            if (exc is JSException jsEx)
+            {
+                exMessage += Environment.NewLine + jsEx.StackTrace;
+            }
+            Console.WriteLine(exMessage);
 
-            status.Append($"<span style='color:red'>Failed - <b>{testName}</b>: {exc.ToString()}</span>");
+            status.Append($"<span style='color:red'>Failed - <b>{testName}</b>: {exMessage.Replace(Environment.NewLine, "<br>")}</span>");
 
             status.Append("<div class='excontext'></div>");
 
             status.Find(".excontext").Text("Test Container: " + tc.Html());
             status.Append("<div class='resultcontext'></div>");
-            status.Find(".resultcontext").Text("Result: " + result.Html());
-            GlobalJS.Console.Log(testName, tc, result);
+            status.Find(".resultcontext").Text("Result: " + result?.Html());
+            GlobalJS.Console.Log(testName, tc.JSObject, result?.JSObject, exMessage);
             // if exc contains data key "html" then Append it to the test container
             //if (exc.Data.Contains("html"))
             //{

--- a/SerratedJQLibrary/Tests.Shared/Tests.Shared.csproj
+++ b/SerratedJQLibrary/Tests.Shared/Tests.Shared.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -12,10 +12,15 @@
   </ItemGroup>
 
   <ItemGroup>
-	  <ProjectReference Include="..\JSInteropHelpers\JSInteropHelpers.csproj" />
-	  <ProjectReference Include="..\SerratedJQ\SerratedJQ.csproj" />
-    <!--<PackageReference Include="SerratedSharp.JSInteropHelpers" Version="0.1.7" />
-    <PackageReference Include="SerratedSharp.SerratedJQ" Version="0.1.7.1" />-->
+
+	  <!-- Use ProjectReference when building with SerratedJSInterop repo alongside (e.g. multi-root workspace). For package-only consumers, use PackageReference to SerratedSharp.SerratedJSInterop 0.3.1. -->
+	  <ProjectReference Include="..\..\..\SerratedJSInterop\SerratedJSInterop\SerratedJSInterop.csproj" Condition="Exists('..\..\..\SerratedJSInterop\SerratedJSInterop\SerratedJSInterop.csproj')" />
+	  <PackageReference Include="SerratedSharp.SerratedJSInterop" Version="0.3.2" Condition="!Exists('..\..\..\SerratedJSInterop\SerratedJSInterop\SerratedJSInterop.csproj')" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Reference SerratedJQ so shared tests can use its types -->
+    <ProjectReference Include="..\SerratedJQ\SerratedJQ.csproj" />
   </ItemGroup>
 
 </Project>

--- a/SerratedJQLibrary/Tests.Wasm/ClassAttributes.cs
+++ b/SerratedJQLibrary/Tests.Wasm/ClassAttributes.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Wasm/Copying.cs
+++ b/SerratedJQLibrary/Tests.Wasm/Copying.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Wasm/Data.cs
+++ b/SerratedJQLibrary/Tests.Wasm/Data.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ;
 using SerratedSharp.SerratedJQ.Plain;
 using System;

--- a/SerratedJQLibrary/Tests.Wasm/Events.cs
+++ b/SerratedJQLibrary/Tests.Wasm/Events.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Wasm/GeneralAttributes.cs
+++ b/SerratedJQLibrary/Tests.Wasm/GeneralAttributes.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using System.Linq;

--- a/SerratedJQLibrary/Tests.Wasm/InsertionAround.cs
+++ b/SerratedJQLibrary/Tests.Wasm/InsertionAround.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Wasm/InsertionInside.cs
+++ b/SerratedJQLibrary/Tests.Wasm/InsertionInside.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ;
 using SerratedSharp.SerratedJQ.Plain;
 using System;

--- a/SerratedJQLibrary/Tests.Wasm/InsertionOutside.cs
+++ b/SerratedJQLibrary/Tests.Wasm/InsertionOutside.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/SerratedJQLibrary/Tests.Wasm/InstanceProperties.cs
+++ b/SerratedJQLibrary/Tests.Wasm/InstanceProperties.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Wasm/MiscTraversal.cs
+++ b/SerratedJQLibrary/Tests.Wasm/MiscTraversal.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Wasm/Program.cs
+++ b/SerratedJQLibrary/Tests.Wasm/Program.cs
@@ -1,14 +1,14 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using System.Runtime.InteropServices.JavaScript;
 
-//using SerratedSharp.JSInteropHelpers;
+//using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using Tests.Wasm;
 

--- a/SerratedJQLibrary/Tests.Wasm/Removal.cs
+++ b/SerratedJQLibrary/Tests.Wasm/Removal.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Wasm/StyleProperties.cs
+++ b/SerratedJQLibrary/Tests.Wasm/StyleProperties.cs
@@ -1,4 +1,4 @@
-﻿using SerratedSharp.JSInteropHelpers;
+using SerratedSharp.SerratedJSInterop;
 using SerratedSharp.SerratedJQ.Plain;
 using System;
 using Wasm;

--- a/SerratedJQLibrary/Tests.Wasm/Tests.UnoWasm.csproj
+++ b/SerratedJQLibrary/Tests.Wasm/Tests.UnoWasm.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup Label="Globals">
 		<SccProjectName></SccProjectName>
@@ -10,7 +10,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
- Deprecates JSInteropHelpers usage in favor of SerratedJSInterop
- Adds JQuery .Get() implementations used for getting underlying HtmlElement JSObject references to assist in comptaibility with non-JQuery interop.